### PR TITLE
[proof] EVM contracts and adversarial simulation

### DIFF
--- a/packages/evm-contracts/contracts/GoldClob.sol
+++ b/packages/evm-contracts/contracts/GoldClob.sol
@@ -347,20 +347,20 @@ contract GoldClob is AccessControl, ReentrancyGuard {
 
         MarketStatus status = syncMarketFromOracle(duelKey, marketKind);
         Position storage position = positions[key][msg.sender];
+        bool hasPosition = position.aShares > 0 || position.bShares > 0 || position.aStake > 0 || position.bStake > 0;
+        require(hasPosition, "nothing to claim");
 
         uint256 payout = 0;
         if (status == MarketStatus.RESOLVED) {
             uint256 winningShares = market.winner == Side.A ? position.aShares : position.bShares;
-            if (winningShares == 0) revert NothingToClaim();
-
-            uint256 fee = (winningShares * winningsMarketMakerFeeBps) / MAX_FEE_BPS;
-            payout = winningShares - fee;
             _clearPosition(position);
-
-            if (fee > 0) payable(marketMaker).sendValue(fee);
+            if (winningShares > 0) {
+                uint256 fee = (winningShares * winningsMarketMakerFeeBps) / MAX_FEE_BPS;
+                payout = winningShares - fee;
+                if (fee > 0) payable(marketMaker).sendValue(fee);
+            }
         } else if (status == MarketStatus.CANCELLED) {
             payout = uint256(position.aStake) + uint256(position.bStake);
-            if (payout == 0) revert NothingToClaim();
             _clearPosition(position);
         } else {
             revert MarketNotSettled();

--- a/packages/evm-contracts/package.json
+++ b/packages/evm-contracts/package.json
@@ -1,44 +1,44 @@
 {
-    "name": "@hyperbet/evm-contracts",
-    "version": "0.1.0",
-    "private": true,
-    "type": "commonjs",
-    "scripts": {
+  "name": "@hyperbet/evm-contracts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
     "compile": "hardhat compile",
     "test": "hardhat test",
     "test:anvil": "bash scripts/run-anvil-contract-suite.sh",
-    "test:fuzz": "hardhat test test/GoldClob.fuzz.ts",
-    "test:foundry": "forge test",
+    "test:fuzz": "forge test --match-path 'test/fuzz/**/*.t.sol'",
+    "test:foundry": "forge test --match-path 'test/**/*.t.sol' --no-match-path 'test/fuzz/**'",
     "analyze:slither": "slither . --exclude-dependencies --filter-paths 'node_modules|out|cache|lib' --exclude timestamp,pragma,solc-version,cyclomatic-complexity",
     "deploy:bsc-testnet": "hardhat run scripts/deploy.ts --network bscTestnet",
-        "deploy:base-sepolia": "hardhat run scripts/deploy.ts --network baseSepolia",
-        "deploy:avax-fuji": "hardhat run scripts/deploy.ts --network avaxFuji",
-        "deploy:bsc": "hardhat run scripts/deploy.ts --network bsc",
-        "deploy:base": "hardhat run scripts/deploy.ts --network base",
-        "deploy:avax": "hardhat run scripts/deploy.ts --network avax",
-        "deploy:duel-oracle:bsc-testnet": "hardhat run scripts/deploy-duel-oracle.ts --network bscTestnet",
-        "deploy:duel-oracle:base-sepolia": "hardhat run scripts/deploy-duel-oracle.ts --network baseSepolia",
-        "deploy:duel-oracle:avax-fuji": "hardhat run scripts/deploy-duel-oracle.ts --network avaxFuji",
-        "deploy:duel-oracle:bsc": "hardhat run scripts/deploy-duel-oracle.ts --network bsc",
-        "deploy:duel-oracle:base": "hardhat run scripts/deploy-duel-oracle.ts --network base",
-        "deploy:duel-oracle:avax": "hardhat run scripts/deploy-duel-oracle.ts --network avax",
-        "simulate:localnet": "hardhat run scripts/simulate-localnet.ts",
+    "deploy:base-sepolia": "hardhat run scripts/deploy.ts --network baseSepolia",
+    "deploy:avax-fuji": "hardhat run scripts/deploy.ts --network avaxFuji",
+    "deploy:bsc": "hardhat run scripts/deploy.ts --network bsc",
+    "deploy:base": "hardhat run scripts/deploy.ts --network base",
+    "deploy:avax": "hardhat run scripts/deploy.ts --network avax",
+    "deploy:duel-oracle:bsc-testnet": "hardhat run scripts/deploy-duel-oracle.ts --network bscTestnet",
+    "deploy:duel-oracle:base-sepolia": "hardhat run scripts/deploy-duel-oracle.ts --network baseSepolia",
+    "deploy:duel-oracle:avax-fuji": "hardhat run scripts/deploy-duel-oracle.ts --network avaxFuji",
+    "deploy:duel-oracle:bsc": "hardhat run scripts/deploy-duel-oracle.ts --network bsc",
+    "deploy:duel-oracle:base": "hardhat run scripts/deploy-duel-oracle.ts --network base",
+    "deploy:duel-oracle:avax": "hardhat run scripts/deploy-duel-oracle.ts --network avax",
+    "simulate:localnet": "hardhat run scripts/simulate-localnet.ts",
     "simulate:adversarial:anvil": "ts-node --transpile-only scripts/simulate-adversarial-localnet.ts"
-    },
-    "devDependencies": {
-        "@types/chai": "^5.2.3",
-        "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
-        "@nomicfoundation/hardhat-ethers": "^3.1.0",
-        "@types/mocha": "^10.0.6",
-        "@types/node": "^25.3.0",
-        "chai": "^6.2.2",
-        "dotenv": "^17.3.1",
-        "ethers": "^6.11.1",
-        "hardhat": "^2.26.0",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.3"
-    },
-    "dependencies": {
-        "@openzeppelin/contracts": "^5.0.0"
-    }
+  },
+  "devDependencies": {
+    "@types/chai": "^5.2.3",
+    "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
+    "@nomicfoundation/hardhat-ethers": "^3.1.0",
+    "@types/mocha": "^10.0.6",
+    "@types/node": "^25.3.0",
+    "chai": "^6.2.2",
+    "dotenv": "^17.3.1",
+    "ethers": "^6.11.1",
+    "hardhat": "^2.26.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts": "^5.0.0"
+  }
 }

--- a/packages/evm-contracts/test/GoldClob.ts
+++ b/packages/evm-contracts/test/GoldClob.ts
@@ -328,6 +328,96 @@ describe("GoldClob", function () {
     expect(claimReceipt?.status).to.equal(1);
   });
 
+  it("clears losing trader state on first post-resolution claim and rejects repeated claims", async function () {
+    const { clob, oracle, operator, reporter, traderA, traderB } =
+      await deployFixture();
+    const duel = duelKey("duel-loser-clear");
+
+    const openedAt = await upsertOpenDuel(oracle, reporter, duel);
+    await clob
+      .connect(operator)
+      .createMarketForDuel(duel, MARKET_KIND_DUEL_WINNER);
+
+    const amount = 1000n;
+    await clob
+      .connect(traderA)
+      .placeOrder(duel, MARKET_KIND_DUEL_WINNER, SELL_SIDE, 600, amount, {
+        value: quoteCost(SELL_SIDE, 600, amount) + 20n,
+      });
+    await clob
+      .connect(traderB)
+      .placeOrder(duel, MARKET_KIND_DUEL_WINNER, BUY_SIDE, 600, amount, {
+        value: quoteCost(BUY_SIDE, 600, amount) + 20n,
+      });
+
+    const marketKey = await clob.marketKey(duel, MARKET_KIND_DUEL_WINNER);
+    const loserBefore = await clob.positions(marketKey, traderA.address);
+    expect(loserBefore.bShares).to.equal(amount);
+    expect(loserBefore.bStake).to.equal(quoteCost(SELL_SIDE, 600, amount));
+
+    await oracle
+      .connect(reporter)
+      .reportResult(
+        duel,
+        SIDE_A,
+        99,
+        ethers.keccak256(ethers.toUtf8Bytes("replay-loser")),
+        ethers.keccak256(ethers.toUtf8Bytes("result-loser")),
+        openedAt + 180n,
+        "resolved-loser",
+      );
+    await clob
+      .connect(operator)
+      .syncMarketFromOracle(duel, MARKET_KIND_DUEL_WINNER);
+
+    await expectTxSuccess(
+      clob.connect(traderA).claim(duel, MARKET_KIND_DUEL_WINNER),
+    );
+
+    const loserAfter = await clob.positions(marketKey, traderA.address);
+    expect(loserAfter.aShares).to.equal(0n);
+    expect(loserAfter.bShares).to.equal(0n);
+    expect(loserAfter.aStake).to.equal(0n);
+    expect(loserAfter.bStake).to.equal(0n);
+
+    await expect(
+      clob.connect(traderA).claim(duel, MARKET_KIND_DUEL_WINNER),
+    ).to.be.revertedWith("nothing to claim");
+    await expectTxSuccess(
+      clob.connect(traderB).claim(duel, MARKET_KIND_DUEL_WINNER),
+    );
+    await expect(
+      clob.connect(traderB).claim(duel, MARKET_KIND_DUEL_WINNER),
+    ).to.be.revertedWith("nothing to claim");
+  });
+
+  it("rejects claims before the market is settled", async function () {
+    const { clob, oracle, operator, reporter, traderA, traderB } =
+      await deployFixture();
+    const duel = duelKey("duel-unresolved-claim");
+
+    await upsertOpenDuel(oracle, reporter, duel);
+    await clob
+      .connect(operator)
+      .createMarketForDuel(duel, MARKET_KIND_DUEL_WINNER);
+
+    const amount = 1000n;
+    await clob
+      .connect(traderA)
+      .placeOrder(duel, MARKET_KIND_DUEL_WINNER, SELL_SIDE, 600, amount, {
+        value: quoteCost(SELL_SIDE, 600, amount) + 20n,
+      });
+    await clob
+      .connect(traderB)
+      .placeOrder(duel, MARKET_KIND_DUEL_WINNER, BUY_SIDE, 600, amount, {
+        value: quoteCost(BUY_SIDE, 600, amount) + 20n,
+      });
+
+    await expect(
+      clob.connect(traderA).claim(duel, MARKET_KIND_DUEL_WINNER),
+    ).to.be.revertedWithCustomError(clob, "MarketNotSettled");
+  });
+
   it("refunds recorded stake on duel cancellation", async function () {
     const { clob, oracle, operator, reporter, traderA, traderB } =
       await deployFixture();

--- a/packages/evm-contracts/test/GoldClobSettlement.t.sol
+++ b/packages/evm-contracts/test/GoldClobSettlement.t.sol
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+
+import "../contracts/DuelOutcomeOracle.sol";
+import "../contracts/GoldClob.sol";
+
+contract GoldClobSettlementTest is Test {
+    uint8 private constant MARKET_KIND_DUEL_WINNER = 0;
+    uint8 private constant BUY_SIDE = 1;
+    uint8 private constant SELL_SIDE = 2;
+
+    address private admin = address(0xA11CE);
+    address private operator = address(0x0F03);
+    address private reporter = address(0xB0B);
+    address private treasury = address(0x7001);
+    address private marketMaker = address(0xAA01);
+    address private traderA = address(0xAAA1);
+    address private traderB = address(0xBBB1);
+
+    DuelOutcomeOracle private oracle;
+    GoldClob private clob;
+
+    function setUp() public {
+        vm.txGasPrice(0);
+        vm.warp(1_000);
+
+        oracle = new DuelOutcomeOracle(admin, reporter);
+
+        vm.prank(admin);
+        clob = new GoldClob(admin, operator, address(oracle), treasury, marketMaker);
+
+        vm.deal(traderA, 100 ether);
+        vm.deal(traderB, 100 ether);
+    }
+
+    function testWinnerClaimPaysOutAndClearsState() public {
+        bytes32 duel = _createOpenMarket("winner-payout");
+        uint128 amount = 1_000;
+
+        _matchTrade(duel, 600, amount);
+        _resolveDuel(duel, DuelOutcomeOracle.Side.A);
+
+        bytes32 key = clob.marketKey(duel, MARKET_KIND_DUEL_WINNER);
+        (uint128 aSharesBefore,,, ) = clob.positions(key, traderB);
+        assertEq(aSharesBefore, amount, "winner should hold A shares before claim");
+
+        uint256 traderBefore = traderB.balance;
+        uint256 mmBefore = marketMaker.balance;
+
+        vm.prank(traderB);
+        clob.claim(duel, MARKET_KIND_DUEL_WINNER);
+
+        uint256 expectedFee = (uint256(amount) * 200) / 10_000;
+        assertEq(traderB.balance - traderBefore, uint256(amount) - expectedFee, "winner payout should net MM fee");
+        assertEq(marketMaker.balance - mmBefore, expectedFee, "MM should receive winnings fee");
+
+        (uint128 aSharesAfter, uint128 bSharesAfter, uint128 aStakeAfter, uint128 bStakeAfter) =
+            clob.positions(key, traderB);
+        assertEq(aSharesAfter, 0, "winner A shares should clear");
+        assertEq(bSharesAfter, 0, "winner B shares should clear");
+        assertEq(aStakeAfter, 0, "winner A stake should clear");
+        assertEq(bStakeAfter, 0, "winner B stake should clear");
+
+        vm.expectRevert(bytes("nothing to claim"));
+        vm.prank(traderB);
+        clob.claim(duel, MARKET_KIND_DUEL_WINNER);
+    }
+
+    function testResolvedLoserClaimClearsStateAndRejectsRepeat() public {
+        bytes32 duel = _createOpenMarket("loser-clear");
+        uint128 amount = 1_000;
+
+        _matchTrade(duel, 600, amount);
+        _resolveDuel(duel, DuelOutcomeOracle.Side.A);
+
+        bytes32 key = clob.marketKey(duel, MARKET_KIND_DUEL_WINNER);
+        (, uint128 bSharesBefore,, uint128 bStakeBefore) = clob.positions(key, traderA);
+        assertEq(bSharesBefore, amount, "loser should hold B shares before claim");
+        assertEq(bStakeBefore, _quoteCost(SELL_SIDE, 600, amount), "loser stake should be tracked");
+
+        uint256 traderBefore = traderA.balance;
+
+        vm.prank(traderA);
+        clob.claim(duel, MARKET_KIND_DUEL_WINNER);
+
+        assertEq(traderA.balance, traderBefore, "loser cleanup should not pay out");
+
+        (uint128 aSharesAfter, uint128 bSharesAfter, uint128 aStakeAfter, uint128 bStakeAfter) =
+            clob.positions(key, traderA);
+        assertEq(aSharesAfter, 0, "loser A shares should clear");
+        assertEq(bSharesAfter, 0, "loser B shares should clear");
+        assertEq(aStakeAfter, 0, "loser A stake should clear");
+        assertEq(bStakeAfter, 0, "loser B stake should clear");
+
+        vm.expectRevert(bytes("nothing to claim"));
+        vm.prank(traderA);
+        clob.claim(duel, MARKET_KIND_DUEL_WINNER);
+    }
+
+    function testCancelledMarketRefundsStakeAndClearsState() public {
+        bytes32 duel = _createOpenMarket("cancelled-refund");
+        uint128 amount = 1_000;
+
+        _matchTrade(duel, 600, amount);
+
+        bytes32 key = clob.marketKey(duel, MARKET_KIND_DUEL_WINNER);
+        (, uint128 bSharesBefore,, uint128 bStakeBefore) = clob.positions(key, traderA);
+        assertEq(bSharesBefore, amount, "seller should hold B shares before cancel");
+
+        uint256 traderBefore = traderA.balance;
+        vm.prank(reporter);
+        oracle.cancelDuel(duel, "cancelled");
+
+        vm.prank(traderA);
+        clob.claim(duel, MARKET_KIND_DUEL_WINNER);
+
+        assertEq(traderA.balance - traderBefore, bStakeBefore, "cancelled market should refund full stake");
+
+        (uint128 aSharesAfter, uint128 bSharesAfter, uint128 aStakeAfter, uint128 bStakeAfter) =
+            clob.positions(key, traderA);
+        assertEq(aSharesAfter, 0, "cancelled A shares should clear");
+        assertEq(bSharesAfter, 0, "cancelled B shares should clear");
+        assertEq(aStakeAfter, 0, "cancelled A stake should clear");
+        assertEq(bStakeAfter, 0, "cancelled B stake should clear");
+
+        vm.expectRevert(bytes("nothing to claim"));
+        vm.prank(traderA);
+        clob.claim(duel, MARKET_KIND_DUEL_WINNER);
+    }
+
+    function testRejectsClaimBeforeSettlement() public {
+        bytes32 duel = _createOpenMarket("unresolved-claim");
+        _matchTrade(duel, 600, 1_000);
+
+        vm.expectRevert(GoldClob.MarketNotSettled.selector);
+        vm.prank(traderA);
+        clob.claim(duel, MARKET_KIND_DUEL_WINNER);
+    }
+
+    function _createOpenMarket(string memory label) private returns (bytes32 duel) {
+        duel = _duelKey(label);
+        bytes32 participantA = _hashLabel(string.concat(label, "-a"));
+        bytes32 participantB = _hashLabel(string.concat(label, "-b"));
+        uint64 nowTs = uint64(block.timestamp);
+
+        vm.prank(reporter);
+        oracle.upsertDuel(
+            duel,
+            participantA,
+            participantB,
+            nowTs,
+            nowTs + 60,
+            nowTs + 120,
+            label,
+            DuelOutcomeOracle.DuelStatus.BETTING_OPEN
+        );
+
+        vm.prank(operator);
+        clob.createMarketForDuel(duel, MARKET_KIND_DUEL_WINNER);
+    }
+
+    function _matchTrade(bytes32 duel, uint16 price, uint128 amount) private {
+        vm.prank(traderA);
+        clob.placeOrder{value: _totalOrderValue(SELL_SIDE, price, amount)}(
+            duel,
+            MARKET_KIND_DUEL_WINNER,
+            SELL_SIDE,
+            price,
+            amount
+        );
+
+        vm.prank(traderB);
+        clob.placeOrder{value: _totalOrderValue(BUY_SIDE, price, amount)}(
+            duel,
+            MARKET_KIND_DUEL_WINNER,
+            BUY_SIDE,
+            price,
+            amount
+        );
+    }
+
+    function _resolveDuel(bytes32 duel, DuelOutcomeOracle.Side winner) private {
+        vm.prank(reporter);
+        oracle.reportResult(
+            duel,
+            winner,
+            42,
+            _hashLabel("replay"),
+            _hashLabel("result"),
+            uint64(block.timestamp + 180),
+            "resolved"
+        );
+    }
+
+    function _duelKey(string memory label) private pure returns (bytes32) {
+        return keccak256(bytes(label));
+    }
+
+    function _hashLabel(string memory label) private pure returns (bytes32) {
+        return keccak256(bytes(label));
+    }
+
+    function _quoteCost(uint8 side, uint16 price, uint128 amount) private pure returns (uint256) {
+        uint256 priceComponent = side == BUY_SIDE ? price : 1000 - price;
+        uint256 total = uint256(amount) * priceComponent;
+        require(total % 1000 == 0, "precision error");
+        return total / 1000;
+    }
+
+    function _totalOrderValue(uint8 side, uint16 price, uint128 amount) private pure returns (uint256) {
+        uint256 cost = _quoteCost(side, price, amount);
+        uint256 treasuryFee = (cost * 100) / 10_000;
+        uint256 marketMakerFee = (cost * 100) / 10_000;
+        return cost + treasuryFee + marketMakerFee;
+    }
+}

--- a/packages/evm-contracts/test/fuzz/GoldClobFuzz.t.sol
+++ b/packages/evm-contracts/test/fuzz/GoldClobFuzz.t.sol
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+
+import "../../contracts/DuelOutcomeOracle.sol";
+import "../../contracts/GoldClob.sol";
+
+contract GoldClobFuzzTest is Test {
+    uint8 private constant MARKET_KIND_DUEL_WINNER = 0;
+    uint8 private constant BUY_SIDE = 1;
+    uint8 private constant SELL_SIDE = 2;
+
+    address private admin = address(0xA11CE);
+    address private operator = address(0x0F03);
+    address private reporter = address(0xB0B);
+    address private treasury = address(0x7001);
+    address private marketMaker = address(0xAA01);
+    address private traderA = address(0xAAA1);
+    address private traderB = address(0xBBB1);
+
+    DuelOutcomeOracle private oracle;
+    GoldClob private clob;
+
+    function setUp() public {
+        vm.txGasPrice(0);
+        vm.warp(1_000);
+
+        oracle = new DuelOutcomeOracle(admin, reporter);
+
+        vm.prank(admin);
+        clob = new GoldClob(admin, operator, address(oracle), treasury, marketMaker);
+
+        vm.deal(traderA, 1_000 ether);
+        vm.deal(traderB, 1_000 ether);
+    }
+
+    function testFuzz_RevertsWhenOrderValueIsUnderfunded(
+        uint8 sideSeed,
+        uint16 rawPrice,
+        uint96 rawAmountUnits,
+        uint256 rawShortfall
+    ) public {
+        bytes32 duel = _createOpenMarket("underfunded-order");
+        uint8 side = sideSeed % 2 == 0 ? BUY_SIDE : SELL_SIDE;
+        uint16 price = _boundPrice(rawPrice);
+        uint128 amount = _boundAmount(rawAmountUnits, 1, 200);
+        uint256 requiredValue = _totalOrderValue(side, price, amount);
+        uint256 shortfall = bound(rawShortfall, 1, requiredValue);
+
+        vm.expectRevert(GoldClob.InsufficientNativeValue.selector);
+        vm.prank(traderA);
+        clob.placeOrder{value: requiredValue - shortfall}(
+            duel,
+            MARKET_KIND_DUEL_WINNER,
+            side,
+            price,
+            amount
+        );
+    }
+
+    function testFuzz_CancelRefundsRemainingQuoteCostAndClearsQueue(
+        uint16 rawPrice,
+        uint96 rawMakerUnits,
+        uint96 rawFillUnits
+    ) public {
+        bytes32 duel = _createOpenMarket("cancel-refund");
+        uint16 price = _boundPrice(rawPrice);
+        uint256 makerUnits = bound(uint256(rawMakerUnits), 2, 200);
+        uint128 makerAmount = uint128(makerUnits * 1_000);
+        uint128 fillAmount = uint128(bound(uint256(rawFillUnits), 1, makerUnits - 1) * 1_000);
+
+        vm.prank(traderA);
+        clob.placeOrder{value: _totalOrderValue(BUY_SIDE, price, makerAmount)}(
+            duel,
+            MARKET_KIND_DUEL_WINNER,
+            BUY_SIDE,
+            price,
+            makerAmount
+        );
+
+        vm.prank(traderB);
+        clob.placeOrder{value: _totalOrderValue(SELL_SIDE, price, fillAmount)}(
+            duel,
+            MARKET_KIND_DUEL_WINNER,
+            SELL_SIDE,
+            price,
+            fillAmount
+        );
+
+        uint128 remainingAmount = makerAmount - fillAmount;
+        uint256 expectedRefund = _quoteCost(BUY_SIDE, price, remainingAmount);
+        uint256 traderBefore = traderA.balance;
+
+        vm.prank(traderA);
+        clob.cancelOrder(duel, MARKET_KIND_DUEL_WINNER, 1);
+
+        assertEq(traderA.balance - traderBefore, expectedRefund, "cancel should refund remaining quote cost");
+
+        (uint64 headOrderId, uint64 tailOrderId, uint128 totalOpen) = clob.getPriceLevel(
+            duel,
+            MARKET_KIND_DUEL_WINNER,
+            BUY_SIDE,
+            price
+        );
+        assertEq(headOrderId, 0, "bid level head should clear");
+        assertEq(tailOrderId, 0, "bid level tail should clear");
+        assertEq(totalOpen, 0, "bid level open total should clear");
+
+        GoldClob.Market memory market = clob.getMarket(duel, MARKET_KIND_DUEL_WINNER);
+        assertEq(market.bestBid, 0, "best bid should clear after cancelling the only resting order");
+
+        (
+            uint64 orderId,
+            uint8 side,
+            uint16 orderPrice,
+            address maker,
+            uint128 amount,
+            uint128 filled,
+            uint64 prevOrderId,
+            uint64 nextOrderId,
+            bool active
+        ) = clob.orders(clob.marketKey(duel, MARKET_KIND_DUEL_WINNER), 1);
+        assertEq(orderId, 1, "order id should remain stable");
+        assertEq(side, BUY_SIDE, "order side should remain BUY");
+        assertEq(orderPrice, price, "order price should remain stable");
+        assertEq(maker, traderA, "order maker should remain traderA");
+        assertEq(amount, makerAmount, "order amount should remain stable");
+        assertEq(filled, makerAmount, "cancel should mark remaining size as filled");
+        assertEq(prevOrderId, 0, "cancel should clear previous order link");
+        assertEq(nextOrderId, 0, "cancel should clear next order link");
+        assertTrue(!active, "cancel should deactivate the order");
+    }
+
+    function testFuzz_ResolvedClaimClearsPositionAndPaysWinner(
+        uint16 rawPrice,
+        uint96 rawAmountUnits
+    ) public {
+        bytes32 duel = _createOpenMarket("resolved-claim");
+        uint16 price = _boundPrice(rawPrice);
+        uint128 amount = _boundAmount(rawAmountUnits, 1, 200);
+
+        _matchTrade(duel, price, amount);
+        _resolveDuel(duel, DuelOutcomeOracle.Side.A);
+
+        bytes32 key = clob.marketKey(duel, MARKET_KIND_DUEL_WINNER);
+        (uint128 aSharesBefore, uint128 bSharesBefore, uint128 aStakeBefore, uint128 bStakeBefore) =
+            clob.positions(key, traderB);
+        assertEq(aSharesBefore, amount, "winner should hold A shares before claim");
+
+        uint256 traderBefore = traderB.balance;
+        uint256 mmBefore = marketMaker.balance;
+
+        vm.prank(traderB);
+        clob.claim(duel, MARKET_KIND_DUEL_WINNER);
+
+        uint256 expectedFee = (uint256(amount) * 200) / 10_000;
+        assertEq(traderB.balance - traderBefore, uint256(amount) - expectedFee, "winner payout should net MM fee");
+        assertEq(marketMaker.balance - mmBefore, expectedFee, "MM should receive the winnings fee");
+
+        _assertClearedPosition(key, traderB);
+        assertEq(bSharesBefore, 0, "winner should not hold B shares");
+        assertEq(aStakeBefore, _quoteCost(BUY_SIDE, price, amount), "winner A stake should be tracked");
+        assertEq(bStakeBefore, 0, "winner B stake should be zero");
+    }
+
+    function testFuzz_CancelledClaimClearsPositionAndRefundsStake(
+        uint16 rawPrice,
+        uint96 rawAmountUnits
+    ) public {
+        bytes32 duel = _createOpenMarket("cancelled-claim");
+        uint16 price = _boundPrice(rawPrice);
+        uint128 amount = _boundAmount(rawAmountUnits, 1, 200);
+
+        _matchTrade(duel, price, amount);
+
+        bytes32 key = clob.marketKey(duel, MARKET_KIND_DUEL_WINNER);
+        (, uint128 bSharesBefore,, uint128 bStakeBefore) = clob.positions(key, traderA);
+        assertEq(bSharesBefore, amount, "seller should hold B shares before cancellation");
+
+        uint256 traderBefore = traderA.balance;
+
+        vm.prank(reporter);
+        oracle.cancelDuel(duel, "cancelled");
+
+        vm.prank(traderA);
+        clob.claim(duel, MARKET_KIND_DUEL_WINNER);
+
+        assertEq(traderA.balance - traderBefore, bStakeBefore, "cancelled market should refund tracked stake");
+        _assertClearedPosition(key, traderA);
+    }
+
+    function _createOpenMarket(string memory label) private returns (bytes32 duel) {
+        duel = _duelKey(label);
+        bytes32 participantA = _hashLabel(string.concat(label, "-a"));
+        bytes32 participantB = _hashLabel(string.concat(label, "-b"));
+        uint64 nowTs = uint64(block.timestamp);
+
+        vm.prank(reporter);
+        oracle.upsertDuel(
+            duel,
+            participantA,
+            participantB,
+            nowTs,
+            nowTs + 60,
+            nowTs + 120,
+            label,
+            DuelOutcomeOracle.DuelStatus.BETTING_OPEN
+        );
+
+        vm.prank(operator);
+        clob.createMarketForDuel(duel, MARKET_KIND_DUEL_WINNER);
+    }
+
+    function _matchTrade(bytes32 duel, uint16 price, uint128 amount) private {
+        vm.prank(traderA);
+        clob.placeOrder{value: _totalOrderValue(SELL_SIDE, price, amount)}(
+            duel,
+            MARKET_KIND_DUEL_WINNER,
+            SELL_SIDE,
+            price,
+            amount
+        );
+
+        vm.prank(traderB);
+        clob.placeOrder{value: _totalOrderValue(BUY_SIDE, price, amount)}(
+            duel,
+            MARKET_KIND_DUEL_WINNER,
+            BUY_SIDE,
+            price,
+            amount
+        );
+    }
+
+    function _resolveDuel(bytes32 duel, DuelOutcomeOracle.Side winner) private {
+        vm.prank(reporter);
+        oracle.reportResult(
+            duel,
+            winner,
+            42,
+            _hashLabel("replay"),
+            _hashLabel("result"),
+            uint64(block.timestamp + 180),
+            "resolved"
+        );
+    }
+
+    function _assertClearedPosition(bytes32 key, address trader) private view {
+        (uint128 aShares, uint128 bShares, uint128 aStake, uint128 bStake) =
+            clob.positions(key, trader);
+        assertEq(aShares, 0, "A shares should clear");
+        assertEq(bShares, 0, "B shares should clear");
+        assertEq(aStake, 0, "A stake should clear");
+        assertEq(bStake, 0, "B stake should clear");
+    }
+
+    function _boundPrice(uint16 rawPrice) private pure returns (uint16) {
+        return uint16(bound(uint256(rawPrice), 1, 999));
+    }
+
+    function _boundAmount(
+        uint96 rawAmountUnits,
+        uint256 minUnits,
+        uint256 maxUnits
+    ) private pure returns (uint128) {
+        return uint128(bound(uint256(rawAmountUnits), minUnits, maxUnits) * 1_000);
+    }
+
+    function _duelKey(string memory label) private pure returns (bytes32) {
+        return keccak256(bytes(label));
+    }
+
+    function _hashLabel(string memory label) private pure returns (bytes32) {
+        return keccak256(bytes(label));
+    }
+
+    function _quoteCost(uint8 side, uint16 price, uint128 amount) private pure returns (uint256) {
+        uint256 priceComponent = side == BUY_SIDE ? price : 1_000 - price;
+        return (uint256(amount) * priceComponent) / 1_000;
+    }
+
+    function _totalOrderValue(uint8 side, uint16 price, uint128 amount) private pure returns (uint256) {
+        uint256 cost = _quoteCost(side, price, amount);
+        uint256 treasuryFee = (cost * 100) / 10_000;
+        uint256 marketMakerFee = (cost * 100) / 10_000;
+        return cost + treasuryFee + marketMakerFee;
+    }
+}

--- a/packages/hyperbet-mm-core/src/index.ts
+++ b/packages/hyperbet-mm-core/src/index.ts
@@ -225,7 +225,9 @@ export interface PredictionMarketStatusRecord
 }
 
 export interface ScenarioResult {
+  scenarioId: string;
   name: string;
+  family: string;
   seed: string;
   chainKey: BettingChainKey;
   attackerPnl: number;
@@ -238,6 +240,8 @@ export interface ScenarioResult {
   lockTransitionLatencyMs: number | null;
   resolvedCorrectly: boolean;
   claimCorrectly: boolean;
+  passed: boolean;
+  degraded: boolean;
   gates: MitigationGate[];
   traces: AgentActionTrace[];
 }

--- a/packages/simulation-dashboard/package.json
+++ b/packages/simulation-dashboard/package.json
@@ -5,9 +5,11 @@
     "type": "module",
     "scripts": {
         "dev": "tsx src/server.ts",
-        "build": "tsc --noEmit"
+        "build": "tsc --noEmit",
+        "scenario": "tsx src/cli.ts"
     },
     "dependencies": {
+        "@hyperbet/mm-core": "workspace:*",
         "ethers": "^6.11.1",
         "ws": "^8.18.0"
     },

--- a/packages/simulation-dashboard/src/agents.ts
+++ b/packages/simulation-dashboard/src/agents.ts
@@ -1,14 +1,24 @@
 import type { Contract, JsonRpcSigner, JsonRpcProvider } from "ethers";
 import {
+    DEFAULT_MARKET_MAKER_CONFIG,
+    buildQuotePlan,
+    type MarketSnapshot,
+    type QuotePlan,
+} from "@hyperbet/mm-core";
+import type { ScenarioRuntimeProfile } from "./scenario-catalog.js";
+import {
     BUY_SIDE,
     SELL_SIDE,
     MARKET_KIND_DUEL_WINNER,
     quoteCost,
     quoteWithFees,
+    random,
     randomInt,
     clamp,
     MAX_PRICE,
     SIDE_A,
+    sleep,
+    withTimeout,
 } from "./helpers.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -31,9 +41,11 @@ export type SimContext = {
     totalAShares: bigint;
     totalBShares: bigint;
     tick: number;
+    nowMs: number;
     treasuryFeeBps: bigint;
     mmFeeBps: bigint;
     agentActiveOrderIds: number[];
+    scenarioProfile: ScenarioRuntimeProfile | null;
     agentPosition: { aShares: bigint; bShares: bigint; aStake: bigint; bStake: bigint };
 };
 
@@ -78,15 +90,23 @@ export abstract class BaseAgent {
                         ctx.mmFeeBps,
                     ) + 50n; // small buffer
 
-                    const tx = await (this.clob.connect(this.signer) as any).placeOrder(
-                        ctx.duelKey,
-                        MARKET_KIND_DUEL_WINNER,
-                        action.side,
-                        action.price,
-                        action.amount,
-                        { value: valueNeeded },
+                    const tx: any = await withTimeout(
+                        (this.clob.connect(this.signer) as any).placeOrder(
+                            ctx.duelKey,
+                            MARKET_KIND_DUEL_WINNER,
+                            action.side,
+                            action.price,
+                            action.amount,
+                            { value: valueNeeded },
+                        ),
+                        10_000,
+                        `${this.config.name} placeOrder`,
                     );
-                    const receipt = await tx.wait();
+                    const receipt: any = await withTimeout(
+                        tx.wait(),
+                        10_000,
+                        `${this.config.name} placeOrder receipt`,
+                    );
                     this.tradeCount++;
 
                     // Extract order ID from events
@@ -107,15 +127,25 @@ export abstract class BaseAgent {
                     logs.push(
                         `[${this.config.name}] ${sideLabel} @${action.price} x${action.amount} (order #${orderId})`,
                     );
+                    await sleep(25);
                 } else if (action.type === "cancelOrder" && action.orderId) {
                     try {
-                        const tx = await (this.clob.connect(this.signer) as any).cancelOrder(
-                            ctx.duelKey,
-                            MARKET_KIND_DUEL_WINNER,
-                            action.orderId,
+                        const tx: any = await withTimeout(
+                            (this.clob.connect(this.signer) as any).cancelOrder(
+                                ctx.duelKey,
+                                MARKET_KIND_DUEL_WINNER,
+                                action.orderId,
+                            ),
+                            10_000,
+                            `${this.config.name} cancelOrder`,
                         );
-                        await tx.wait();
+                        await withTimeout(
+                            tx.wait(),
+                            10_000,
+                            `${this.config.name} cancelOrder receipt`,
+                        );
                         logs.push(`[${this.config.name}] CANCEL order #${action.orderId}`);
+                        await sleep(25);
                     } catch {
                         // Order was already filled or cancelled — silently clean up
                     }
@@ -152,9 +182,9 @@ export class RetailAgent extends BaseAgent {
     }
 
     decide(ctx: SimContext): AgentAction[] {
-        if (Math.random() < 0.4) return []; // 40% chance of sitting out
+        if (random() < 0.4) return []; // 40% chance of sitting out
 
-        const isBuy = Math.random() > 0.5;
+        const isBuy = random() > 0.5;
         const noise = randomInt(-50, 50);
         const price = clamp(ctx.mid + noise, 10, 990);
         const amount = BigInt(randomInt(1, 5)) * 100000000000000n;
@@ -173,7 +203,8 @@ export class RetailAgent extends BaseAgent {
 
 // ─── Market Maker Agent ──────────────────────────────────────────────────────
 export class MarketMakerAgent extends BaseAgent {
-    private targetSpreadBps = 200;
+    lastPlan: QuotePlan | null = null;
+    lastSnapshot: MarketSnapshot | null = null;
 
     constructor(signer: JsonRpcSigner, clob: Contract) {
         super(
@@ -191,27 +222,93 @@ export class MarketMakerAgent extends BaseAgent {
 
     decide(ctx: SimContext): AgentAction[] {
         const actions: AgentAction[] = [];
+        const shouldReduceOnly = this.activeOrderIds.length >= 6;
+        const runtimeProfile = ctx.scenarioProfile;
+        const nowMs = ctx.nowMs;
+        const staleStreamLagMs = (runtimeProfile?.staleStreamLagTicks ?? 0) * 500;
+        const staleOracleLagMs = (runtimeProfile?.staleOracleLagTicks ?? 0) * 500;
+        const staleRpcLagMs = (runtimeProfile?.staleRpcLagTicks ?? 0) * 500;
+        const betCloseTimeMs =
+            runtimeProfile?.betCloseTick != null
+                ? runtimeProfile.betCloseTick * 500
+                : null;
 
         // Cancel stale orders first
         if (this.activeOrderIds.length > 4) {
-            const toCancel = this.activeOrderIds.slice(0, 2);
+            const toCancel = this.activeOrderIds.slice(0, 1);
             for (const id of toCancel) {
                 actions.push({ type: "cancelOrder", orderId: id });
             }
+            if (shouldReduceOnly) {
+                return actions;
+            }
         }
 
-        const quoteWidth = Math.max(
-            Math.ceil((this.targetSpreadBps * ctx.mid) / 10000),
-            5,
-        );
-        const bidPrice = clamp(Math.floor(ctx.mid - quoteWidth / 2), 10, 990);
-        const askPrice = clamp(Math.ceil(ctx.mid + quoteWidth / 2), 10, 990);
-        const amount = BigInt(randomInt(2, 8)) * 100000000000000n;
+        const snapshot: MarketSnapshot = {
+            chainKey: "bsc",
+            lifecycleStatus: "OPEN",
+            duelKey: ctx.duelKey,
+            marketRef: ctx.marketKey,
+            bestBid: ctx.bestBid > 0 ? ctx.bestBid : null,
+            bestAsk: ctx.bestAsk > 0 ? ctx.bestAsk : null,
+            betCloseTimeMs,
+            exposure: {
+                yes: Number(ctx.agentPosition.aShares / 1000n),
+                no: Number(ctx.agentPosition.bShares / 1000n),
+                openYes: 0,
+                openNo: 0,
+            },
+            lastStreamAtMs: nowMs - staleStreamLagMs,
+            lastOracleAtMs: nowMs - staleOracleLagMs,
+            lastRpcAtMs: nowMs - staleRpcLagMs,
+            quoteAgeMs: this.activeOrderIds.length > 0 ? 2_000 : null,
+        };
+        this.lastSnapshot = snapshot;
 
-        actions.push(
-            { type: "placeOrder", side: BUY_SIDE, price: bidPrice, amount, label: "MM bid" },
-            { type: "placeOrder", side: SELL_SIDE, price: askPrice, amount, label: "MM ask" },
+        const plan = buildQuotePlan(
+            snapshot,
+            {
+                signalPrice: ctx.mid,
+                signalWeight: runtimeProfile?.signalWeight ?? 0.35,
+            },
+            {
+                ...DEFAULT_MARKET_MAKER_CONFIG,
+                minQuoteUnits: 2,
+                maxQuoteUnits: 8,
+                maxInventoryPerSide: 40,
+                maxNetExposure: 25,
+                maxQuoteAgeMs: 2_500,
+                minRefreshIntervalMs: 1_000,
+                betCloseGuardMs:
+                    runtimeProfile?.marketMakerBetCloseGuardMs ??
+                    DEFAULT_MARKET_MAKER_CONFIG.betCloseGuardMs,
+            },
+            nowMs,
         );
+        this.lastPlan = plan;
+
+        if (plan.risk.circuitBreaker.active) {
+            return actions;
+        }
+
+        if (plan.bidPrice != null && plan.bidUnits > 0) {
+            actions.push({
+                type: "placeOrder",
+                side: BUY_SIDE,
+                price: plan.bidPrice,
+                amount: BigInt(plan.bidUnits) * 1000n,
+                label: "MM bid",
+            });
+        }
+        if (plan.askPrice != null && plan.askUnits > 0) {
+            actions.push({
+                type: "placeOrder",
+                side: SELL_SIDE,
+                price: plan.askPrice,
+                amount: BigInt(plan.askUnits) * 1000n,
+                label: "MM ask",
+            });
+        }
 
         return actions;
     }
@@ -234,9 +331,9 @@ export class WhaleAgent extends BaseAgent {
     }
 
     decide(ctx: SimContext): AgentAction[] {
-        if (Math.random() < 0.7) return []; // Only trades 30% of ticks
+        if (random() < 0.7) return []; // Only trades 30% of ticks
 
-        const isBuy = Math.random() > 0.5;
+        const isBuy = random() > 0.5;
         const price = isBuy
             ? clamp(ctx.mid + randomInt(10, 40), 10, 990)
             : clamp(ctx.mid - randomInt(10, 40), 10, 990);
@@ -274,10 +371,10 @@ export class MevFrontrunnerAgent extends BaseAgent {
     }
 
     decide(ctx: SimContext): AgentAction[] {
-        if (Math.random() < 0.6) return [];
+        if (random() < 0.6) return [];
 
         // Simulate front-running by placing aggressive orders at better prices
-        const isBuy = Math.random() > 0.5;
+        const isBuy = random() > 0.5;
         const price = isBuy
             ? clamp(ctx.bestAsk > 0 && ctx.bestAsk < MAX_PRICE ? ctx.bestAsk : ctx.mid + 20, 10, 990)
             : clamp(ctx.bestBid > 0 ? ctx.bestBid : ctx.mid - 20, 10, 990);
@@ -312,7 +409,7 @@ export class SandwichAgent extends BaseAgent {
     }
 
     decide(ctx: SimContext): AgentAction[] {
-        if (Math.random() < 0.7) return [];
+        if (random() < 0.7) return [];
 
         const amount = BigInt(randomInt(1, 5)) * 100000000000000n;
         // Buy before and sell after — in sim, these are sequential
@@ -352,7 +449,7 @@ export class WashTraderAgent extends BaseAgent {
     }
 
     decide(ctx: SimContext): AgentAction[] {
-        if (Math.random() < 0.5) return [];
+        if (random() < 0.5) return [];
 
         const price = clamp(ctx.mid, 10, 990);
         const amount = BigInt(randomInt(1, 3)) * 100000000000000n;
@@ -429,7 +526,7 @@ export class CabalAgent extends BaseAgent {
     }
 
     decide(ctx: SimContext): AgentAction[] {
-        if (Math.random() < 0.3) return [];
+        if (random() < 0.3) return [];
 
         // Cabal always bets one direction aggressively
         const side = this.biasAgainstHouse ? BUY_SIDE : SELL_SIDE;
@@ -504,10 +601,10 @@ export class StressTestAgent extends BaseAgent {
 
     decide(ctx: SimContext): AgentAction[] {
         const actions: AgentAction[] = [];
-        const count = randomInt(3, 8);
+        const count = randomInt(2, 4);
 
         for (let i = 0; i < count; i++) {
-            const isBuy = Math.random() > 0.5;
+            const isBuy = random() > 0.5;
             const price = clamp(ctx.mid + randomInt(-100, 100), 10, 990);
             const amount = BigInt(randomInt(1, 3)) * 100000000000000n;
             actions.push({
@@ -523,107 +620,37 @@ export class StressTestAgent extends BaseAgent {
     }
 }
 
-// ─── Scenario Presets ────────────────────────────────────────────────────────
+export class CancelReplaceAgent extends BaseAgent {
+    constructor(signer: JsonRpcSigner, clob: Contract) {
+        super(
+            {
+                name: "Cancel/Replace Griefer",
+                strategy: "cancel_replace",
+                description: "Rapidly churns its own quotes to stress cancel-replace paths",
+                enabled: false,
+                color: "#8d6e63",
+            },
+            signer,
+            clob,
+        );
+    }
 
-export type ScenarioPreset = {
-    name: string;
-    description: string;
-    enabledStrategies: string[];
-};
-
-export const SCENARIO_PRESETS: ScenarioPreset[] = [
-    {
-        name: "Normal Market",
-        description: "Retail traders + market maker in a balanced market",
-        enabledStrategies: ["retail", "market_maker"],
-    },
-    {
-        name: "Retail Rush",
-        description: "All retail traders active, overwhelming thin MM liquidity",
-        enabledStrategies: ["retail", "market_maker"],
-    },
-    {
-        name: "Whale Impact",
-        description: "Normal market with a whale dumping large orders",
-        enabledStrategies: ["retail", "market_maker", "whale"],
-    },
-    {
-        name: "MEV Extraction",
-        description: "Multiple MEV bots frontrunning retail order flow",
-        enabledStrategies: ["retail", "market_maker", "mev_frontrunner"],
-    },
-    {
-        name: "Sandwich Attack",
-        description: "Multiple sandwich bots wrapping retail orders",
-        enabledStrategies: ["retail", "market_maker", "sandwich"],
-    },
-    {
-        name: "Double Sandwich + MEV",
-        description: "Both sandwich bots and MEV bots extracting from retail",
-        enabledStrategies: ["retail", "market_maker", "sandwich", "mev_frontrunner"],
-    },
-    {
-        name: "Wash Trading",
-        description: "Wash trader inflating volume alongside normal flow",
-        enabledStrategies: ["retail", "market_maker", "wash_trader"],
-    },
-    {
-        name: "Oracle Attack",
-        description: "Attacker trying to manipulate the duel oracle",
-        enabledStrategies: ["retail", "market_maker", "oracle_attack"],
-    },
-    {
-        name: "Cabal Coordination",
-        description: "Two coordinated cabal groups betting against each other",
-        enabledStrategies: ["retail", "market_maker", "cabal"],
-    },
-    {
-        name: "Arbitrage Hunt",
-        description: "Arbitrageur exploiting tight/crossed spreads",
-        enabledStrategies: ["retail", "market_maker", "arbitrageur"],
-    },
-    {
-        name: "Stress Test",
-        description: "High-frequency flood of orders overwhelming the book",
-        enabledStrategies: ["retail", "market_maker", "stress_test"],
-    },
-    {
-        name: "Whale vs MEV",
-        description: "Whale moving markets while MEV bots try to extract",
-        enabledStrategies: ["market_maker", "whale", "mev_frontrunner"],
-    },
-    {
-        name: "Attack Gauntlet",
-        description: "All attack agents vs thin MM — maximum adversarial pressure",
-        enabledStrategies: [
-            "market_maker",
-            "mev_frontrunner",
-            "sandwich",
-            "wash_trader",
-            "cabal",
-            "arbitrageur",
-        ],
-    },
-    {
-        name: "Liquidity Crisis",
-        description: "Only the underfunded MM and whale — tests insolvency edge cases",
-        enabledStrategies: ["market_maker", "whale"],
-    },
-    {
-        name: "Full Chaos",
-        description: "All 15 agents active simultaneously — maximum entropy",
-        enabledStrategies: [
-            "retail",
-            "market_maker",
-            "whale",
-            "mev_frontrunner",
-            "sandwich",
-            "wash_trader",
-            "oracle_attack",
-            "cabal",
-            "arbitrageur",
-            "stress_test",
-        ],
-    },
-];
-
+    decide(ctx: SimContext): AgentAction[] {
+        const actions: AgentAction[] = [];
+        for (const orderId of this.activeOrderIds.slice(0, 2)) {
+            actions.push({ type: "cancelOrder", orderId, label: "cancel/replace" });
+        }
+        const orderCount = randomInt(1, 2);
+        for (let i = 0; i < orderCount; i += 1) {
+            const isBuy = random() > 0.5;
+            actions.push({
+                type: "placeOrder",
+                side: isBuy ? BUY_SIDE : SELL_SIDE,
+                price: clamp(ctx.mid + randomInt(-15, 15), 10, 990),
+                amount: BigInt(randomInt(1, 2)) * 1000n,
+                label: `cancel-replace #${i + 1}`,
+            });
+        }
+        return actions;
+    }
+}

--- a/packages/simulation-dashboard/src/cli.ts
+++ b/packages/simulation-dashboard/src/cli.ts
@@ -1,0 +1,278 @@
+type ScenarioRunRecord = {
+    runId: string;
+    scenarioId: string;
+    scenarioName: string;
+    seed: string;
+    ticks: number;
+    winner: "A" | "B";
+    freshBaseline: boolean;
+    status: "queued" | "running" | "succeeded" | "failed";
+    stage: string | null;
+    requestedAt: number;
+    startedAt: number | null;
+    finishedAt: number | null;
+    error: string | null;
+    result:
+        | {
+              passed?: boolean;
+              degraded?: boolean;
+          }
+        | null;
+};
+
+type ScenarioPreset = {
+    id: string;
+    name: string;
+    family: string;
+    canonicalSeed: string;
+    matrixSeeds: string[];
+    tier: "gate" | "diagnostic";
+};
+
+const API_BASE_URL = (
+    process.env.SIM_API_URL?.trim() || "http://127.0.0.1:3401"
+).replace(/\/$/, "");
+const POLL_INTERVAL_MS = Number(process.env.SIM_SCENARIO_POLL_MS ?? "1500");
+const RUN_TIMEOUT_MS = Number(process.env.SIM_SCENARIO_TIMEOUT_MS ?? "300000");
+
+function usage(): never {
+    console.error(
+        [
+            "Usage:",
+            "  bun run --cwd packages/simulation-dashboard scenario list",
+            "  bun run --cwd packages/simulation-dashboard scenario gates",
+            "  bun run --cwd packages/simulation-dashboard scenario latest",
+            "  bun run --cwd packages/simulation-dashboard scenario history",
+            "  bun run --cwd packages/simulation-dashboard scenario run <scenario-id-or-name> [--seed=...] [--ticks=...] [--winner=A|B] [--fresh]",
+            "  bun run --cwd packages/simulation-dashboard scenario canonical <scenario-id-or-name> [--fresh]",
+            "  bun run --cwd packages/simulation-dashboard scenario matrix <scenario-id-or-name> [--fresh]",
+            "  bun run --cwd packages/simulation-dashboard scenario suite",
+        ].join("\n"),
+    );
+    process.exit(1);
+}
+
+async function fetchJson(path: string): Promise<any> {
+    const response = await fetch(`${API_BASE_URL}${path}`);
+    const text = await response.text();
+    const payload = text ? JSON.parse(text) : null;
+    if (!response.ok) {
+        throw new Error(payload?.error || `${response.status} ${response.statusText}`);
+    }
+    return payload;
+}
+
+async function sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function printJson(value: unknown): void {
+    console.log(JSON.stringify(value, null, 2));
+}
+
+function getFlagValue(args: string[], flag: string): string | undefined {
+    return args
+        .find((arg) => arg.startsWith(`${flag}=`))
+        ?.slice(flag.length + 1)
+        .trim();
+}
+
+function hasFlag(args: string[], flag: string): boolean {
+    return args.includes(flag);
+}
+
+async function fetchScenarioCatalog(): Promise<{
+    scenarios: ScenarioPreset[];
+    gateScenarios: ScenarioPreset[];
+}> {
+    const payload = await fetchJson("/api/scenarios");
+    return {
+        scenarios: payload.scenarios as ScenarioPreset[],
+        gateScenarios: payload.gateScenarios as ScenarioPreset[],
+    };
+}
+
+function findScenarioPreset(
+    scenarios: readonly ScenarioPreset[],
+    nameOrId: string,
+): ScenarioPreset {
+    const scenario = scenarios.find(
+        (entry) => entry.id === nameOrId || entry.name === nameOrId,
+    );
+    if (!scenario) {
+        throw new Error(`Unknown scenario: ${nameOrId}`);
+    }
+    return scenario;
+}
+
+async function runScenario(
+    scenario: string,
+    options: {
+        seed?: string;
+        ticks?: string;
+        winner?: string;
+        fresh?: boolean;
+    } = {},
+): Promise<ScenarioRunRecord> {
+    const params = new URLSearchParams({
+        name: scenario,
+    });
+    if (options.seed) params.set("seed", options.seed);
+    if (options.ticks) params.set("ticks", options.ticks);
+    if (options.winner) params.set("winner", options.winner);
+    if (options.fresh) params.set("fresh", "1");
+
+    const payload = await fetchJson(
+        `/api/scenarios/run?${params.toString()}`,
+    );
+    const run = payload.run as ScenarioRunRecord | null;
+    if (!run) {
+        throw new Error("Scenario run was accepted without a run record");
+    }
+    return pollRun(run.runId);
+}
+
+function scenarioRunPassed(run: ScenarioRunRecord): boolean {
+    return run.status === "succeeded" && run.result?.passed === true;
+}
+
+async function pollRun(runId: string): Promise<ScenarioRunRecord> {
+    const deadline = Date.now() + RUN_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+        const payload = await fetchJson(
+            `/api/scenarios/results?runId=${encodeURIComponent(runId)}`,
+        );
+        const run = payload.run as ScenarioRunRecord | null;
+        if (!run) {
+            throw new Error(`Run not found: ${runId}`);
+        }
+        if (run.status === "succeeded" || run.status === "failed") {
+            return run;
+        }
+        await sleep(POLL_INTERVAL_MS);
+    }
+    throw new Error(`Scenario run ${runId} timed out after ${RUN_TIMEOUT_MS}ms`);
+}
+
+async function main(): Promise<void> {
+    const [, , command, ...rest] = process.argv;
+
+    switch (command) {
+        case "list": {
+            const payload = await fetchJson("/api/scenarios");
+            printJson({
+                scenarios: payload.scenarios,
+                gateScenarios: payload.gateScenarios,
+                activeRun: payload.activeRun,
+                latest: payload.latest,
+            });
+            return;
+        }
+        case "gates": {
+            const payload = await fetchScenarioCatalog();
+            printJson(payload.gateScenarios);
+            return;
+        }
+        case "latest": {
+            const payload = await fetchJson("/api/scenarios/results");
+            printJson(payload.results?.[0] ?? null);
+            return;
+        }
+        case "history": {
+            const payload = await fetchJson("/api/scenarios/results");
+            printJson({
+                activeRun: payload.activeRun,
+                runs: payload.runs,
+                results: payload.results,
+            });
+            return;
+        }
+        case "run": {
+            const scenario = rest.find((arg) => !arg.startsWith("--"));
+            if (!scenario) {
+                usage();
+            }
+            const seed = getFlagValue(rest, "--seed");
+            const ticks = getFlagValue(rest, "--ticks");
+            const winner = getFlagValue(rest, "--winner");
+            const fresh = hasFlag(rest, "--fresh");
+            const completed = await runScenario(scenario, {
+                seed,
+                ticks,
+                winner,
+                fresh,
+            });
+            printJson(completed);
+            if (!scenarioRunPassed(completed)) {
+                process.exit(1);
+            }
+            return;
+        }
+        case "canonical": {
+            const scenario = rest.find((arg) => !arg.startsWith("--"));
+            if (!scenario) {
+                usage();
+            }
+            const fresh = hasFlag(rest, "--fresh");
+            const { scenarios } = await fetchScenarioCatalog();
+            const preset = findScenarioPreset(scenarios, scenario);
+            const completed = await runScenario(preset.id, {
+                seed: preset.canonicalSeed,
+                fresh,
+            });
+            printJson(completed);
+            if (!scenarioRunPassed(completed)) {
+                process.exit(1);
+            }
+            return;
+        }
+        case "matrix": {
+            const scenario = rest.find((arg) => !arg.startsWith("--"));
+            if (!scenario) {
+                usage();
+            }
+            const fresh = hasFlag(rest, "--fresh");
+            const { scenarios } = await fetchScenarioCatalog();
+            const preset = findScenarioPreset(scenarios, scenario);
+            const seeds = [preset.canonicalSeed, ...preset.matrixSeeds];
+            const results: ScenarioRunRecord[] = [];
+            for (const seed of seeds) {
+                results.push(
+                    await runScenario(preset.id, {
+                        seed,
+                        fresh,
+                    }),
+                );
+            }
+            printJson(results);
+            if (results.some((result) => !scenarioRunPassed(result))) {
+                process.exit(1);
+            }
+            return;
+        }
+        case "suite": {
+            const { gateScenarios } = await fetchScenarioCatalog();
+            const results: ScenarioRunRecord[] = [];
+            for (const preset of gateScenarios) {
+                results.push(
+                    await runScenario(preset.id, {
+                        seed: preset.canonicalSeed,
+                        fresh: true,
+                    }),
+                );
+            }
+            printJson(results);
+            if (results.some((result) => !scenarioRunPassed(result))) {
+                process.exit(1);
+            }
+            return;
+        }
+        default:
+            usage();
+    }
+}
+
+void main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+});

--- a/packages/simulation-dashboard/src/helpers.ts
+++ b/packages/simulation-dashboard/src/helpers.ts
@@ -48,6 +48,18 @@ export type Artifact = {
 };
 
 export function loadArtifact(contractsDir: string, name: string): Artifact {
+    const foundryPath = join(
+        contractsDir,
+        "out",
+        `${name}.sol`,
+        `${name}.json`,
+    );
+    try {
+        return JSON.parse(readFileSync(foundryPath, "utf8")) as Artifact;
+    } catch {
+        // Fall back to Hardhat artifacts.
+    }
+
     // Try the nested contracts/<name>.sol/<name>.json format first
     const nestedPath = join(
         contractsDir,
@@ -76,8 +88,65 @@ export function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export async function withTimeout<T>(
+    promise: Promise<T>,
+    ms: number,
+    label: string,
+): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    try {
+        return await Promise.race([
+            promise,
+            new Promise<never>((_, reject) => {
+                timer = setTimeout(() => {
+                    reject(new Error(`${label} timed out after ${ms}ms`));
+                }, ms);
+            }),
+        ]);
+    } finally {
+        if (timer != null) {
+            clearTimeout(timer);
+        }
+    }
+}
+
+let randomSource: () => number = () => Math.random();
+
+function hashSeed(seed: string | number): number {
+    const value = String(seed);
+    let hash = 2166136261;
+    for (let i = 0; i < value.length; i += 1) {
+        hash ^= value.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+    }
+    return hash >>> 0;
+}
+
+function mulberry32(seed: number): () => number {
+    let state = seed >>> 0;
+    return () => {
+        state = (state + 0x6d2b79f5) >>> 0;
+        let next = state;
+        next = Math.imul(next ^ (next >>> 15), next | 1);
+        next ^= next + Math.imul(next ^ (next >>> 7), next | 61);
+        return ((next ^ (next >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+export function random(): number {
+    return randomSource();
+}
+
+export function setRandomSeed(seed: string | number): void {
+    randomSource = mulberry32(hashSeed(seed));
+}
+
+export function resetRandomSource(): void {
+    randomSource = () => Math.random();
+}
+
 export function randomInt(min: number, max: number): number {
-    return Math.floor(Math.random() * (max - min + 1)) + min;
+    return Math.floor(random() * (max - min + 1)) + min;
 }
 
 export function clamp(value: number, min: number, max: number): number {

--- a/packages/simulation-dashboard/src/scenario-catalog.ts
+++ b/packages/simulation-dashboard/src/scenario-catalog.ts
@@ -1,0 +1,420 @@
+export type ScenarioGateTier = "gate" | "diagnostic";
+export type ScenarioSettlementMode = "resolve" | "cancel";
+export type ScenarioSettlementStatus =
+    | "NULL"
+    | "OPEN"
+    | "LOCKED"
+    | "RESOLVED"
+    | "CANCELLED";
+
+export type ScenarioRuntimeProfile = {
+    settlementMode?: ScenarioSettlementMode;
+    staleStreamLagTicks?: number;
+    staleOracleLagTicks?: number;
+    staleRpcLagTicks?: number;
+    betCloseTick?: number;
+    marketMakerBetCloseGuardMs?: number;
+    signalWeight?: number;
+};
+
+export type ScenarioGatePolicy = {
+    requireDegradationFree?: boolean;
+    requireMmSolvent?: boolean;
+    requireBookIntegrity?: boolean;
+    requireStaleStreamGuard?: boolean;
+    requireStaleOracleGuard?: boolean;
+    requireCloseGuard?: boolean;
+    requireSettlementConsistency?: boolean;
+    requireClaimsProcessed?: boolean;
+    expectedSettlementStatus?: ScenarioSettlementStatus;
+    maxAttackerPnl?: number;
+    maxDrawdownBps?: number;
+    minQuoteUptimeRatio?: number;
+    maxQuoteUptimeRatio?: number;
+    maxOrderChurn?: number;
+};
+
+export type ScenarioPreset = {
+    id: string;
+    name: string;
+    family: string;
+    description: string;
+    enabledStrategies: string[];
+    defaultTicks: number;
+    defaultWinner: "A" | "B";
+    canonicalSeed: string;
+    matrixSeeds: string[];
+    tier: ScenarioGateTier;
+    runtimeProfile?: ScenarioRuntimeProfile;
+    gatePolicy?: ScenarioGatePolicy;
+};
+
+export const SCENARIO_PRESETS: ScenarioPreset[] = [
+    {
+        id: "normal-market",
+        name: "Normal Market",
+        family: "baseline",
+        description: "Retail traders + market maker in a balanced market",
+        enabledStrategies: ["retail", "market_maker"],
+        defaultTicks: 20,
+        defaultWinner: "A",
+        canonicalSeed: "normal-market-seed-1",
+        matrixSeeds: [],
+        tier: "diagnostic",
+    },
+    {
+        id: "retail-rush",
+        name: "Retail Rush",
+        family: "toxic-flow",
+        description: "All retail traders active, overwhelming thin MM liquidity",
+        enabledStrategies: ["retail", "market_maker"],
+        defaultTicks: 24,
+        defaultWinner: "A",
+        canonicalSeed: "retail-rush-seed-1",
+        matrixSeeds: [],
+        tier: "diagnostic",
+    },
+    {
+        id: "stale-signal-sniping",
+        name: "Stale Signal Sniping",
+        family: "stale-signal-sniping",
+        description: "Signal freshness drops while attackers keep trading against stale quotes",
+        enabledStrategies: ["retail", "market_maker", "mev_frontrunner"],
+        defaultTicks: 8,
+        defaultWinner: "A",
+        canonicalSeed: "stale-signal-seed-1",
+        matrixSeeds: ["stale-signal-seed-2", "stale-signal-seed-3"],
+        tier: "gate",
+        runtimeProfile: {
+            staleStreamLagTicks: 12,
+            signalWeight: 0.45,
+        },
+        gatePolicy: {
+            requireDegradationFree: true,
+            requireMmSolvent: true,
+            requireBookIntegrity: true,
+            requireStaleStreamGuard: true,
+            maxAttackerPnl: 0,
+            maxQuoteUptimeRatio: 0.25,
+        },
+    },
+    {
+        id: "stale-oracle-sniping",
+        name: "Stale Oracle Sniping",
+        family: "stale-oracle-sniping",
+        description: "Oracle freshness drops while attackers probe for stale oracle quotes",
+        enabledStrategies: ["retail", "market_maker", "mev_frontrunner"],
+        defaultTicks: 6,
+        defaultWinner: "B",
+        canonicalSeed: "stale-oracle-seed-1",
+        matrixSeeds: ["stale-oracle-seed-2", "stale-oracle-seed-3"],
+        tier: "gate",
+        runtimeProfile: {
+            staleOracleLagTicks: 14,
+            signalWeight: 0.45,
+        },
+        gatePolicy: {
+            requireDegradationFree: true,
+            requireMmSolvent: true,
+            requireBookIntegrity: true,
+            requireStaleOracleGuard: true,
+            maxAttackerPnl: 0,
+            maxQuoteUptimeRatio: 0.25,
+        },
+    },
+    {
+        id: "close-window-race",
+        name: "Close Window Race",
+        family: "close-window-race",
+        description: "Attackers try to race the book into the close window",
+        enabledStrategies: ["retail", "market_maker", "mev_frontrunner"],
+        defaultTicks: 6,
+        defaultWinner: "B",
+        canonicalSeed: "close-window-seed-1",
+        matrixSeeds: ["close-window-seed-2"],
+        tier: "gate",
+        runtimeProfile: {
+            betCloseTick: 4,
+            marketMakerBetCloseGuardMs: 750,
+            signalWeight: 0.35,
+        },
+        gatePolicy: {
+            requireDegradationFree: true,
+            requireMmSolvent: true,
+            requireBookIntegrity: true,
+            requireCloseGuard: true,
+            maxAttackerPnl: 0,
+        },
+    },
+    {
+        id: "whale-impact",
+        name: "Whale Impact",
+        family: "inventory-poisoning",
+        description: "Normal market with a whale dumping large orders",
+        enabledStrategies: ["retail", "market_maker", "whale"],
+        defaultTicks: 10,
+        defaultWinner: "B",
+        canonicalSeed: "inventory-poisoning-seed-1",
+        matrixSeeds: ["inventory-poisoning-seed-2", "inventory-poisoning-seed-3"],
+        tier: "gate",
+        gatePolicy: {
+            requireDegradationFree: true,
+            requireMmSolvent: true,
+            requireBookIntegrity: true,
+            maxAttackerPnl: 0,
+            maxDrawdownBps: 2_000,
+        },
+    },
+    {
+        id: "mev-extraction",
+        name: "MEV Extraction",
+        family: "frontrun-backrun",
+        description: "Multiple MEV bots frontrunning retail order flow",
+        enabledStrategies: ["retail", "market_maker", "mev_frontrunner"],
+        defaultTicks: 10,
+        defaultWinner: "A",
+        canonicalSeed: "mev-extraction-seed-1",
+        matrixSeeds: [],
+        tier: "gate",
+        gatePolicy: {
+            requireDegradationFree: true,
+            requireMmSolvent: true,
+            requireBookIntegrity: true,
+            maxAttackerPnl: 0,
+        },
+    },
+    {
+        id: "sandwich-attack",
+        name: "Sandwich Attack",
+        family: "sandwich",
+        description: "Multiple sandwich bots wrapping retail orders",
+        enabledStrategies: ["retail", "market_maker", "sandwich"],
+        defaultTicks: 8,
+        defaultWinner: "B",
+        canonicalSeed: "sandwich-seed-1",
+        matrixSeeds: ["sandwich-seed-2", "sandwich-seed-3"],
+        tier: "gate",
+        gatePolicy: {
+            requireDegradationFree: true,
+            requireMmSolvent: true,
+            requireBookIntegrity: true,
+            maxAttackerPnl: 0,
+        },
+    },
+    {
+        id: "double-sandwich-mev",
+        name: "Double Sandwich + MEV",
+        family: "sandwich",
+        description: "Both sandwich bots and MEV bots extracting from retail",
+        enabledStrategies: ["retail", "market_maker", "sandwich", "mev_frontrunner"],
+        defaultTicks: 20,
+        defaultWinner: "B",
+        canonicalSeed: "double-sandwich-mev-seed-1",
+        matrixSeeds: [],
+        tier: "diagnostic",
+    },
+    {
+        id: "wash-trading",
+        name: "Wash Trading",
+        family: "wash-self-trade",
+        description: "Wash trader inflating volume alongside normal flow",
+        enabledStrategies: ["retail", "market_maker", "wash_trader"],
+        defaultTicks: 10,
+        defaultWinner: "A",
+        canonicalSeed: "wash-trading-seed-1",
+        matrixSeeds: [],
+        tier: "gate",
+        gatePolicy: {
+            requireDegradationFree: true,
+            requireMmSolvent: true,
+            requireBookIntegrity: true,
+            maxAttackerPnl: 0,
+        },
+    },
+    {
+        id: "oracle-attack",
+        name: "Oracle Attack",
+        family: "oracle-abuse",
+        description: "Attacker trying to manipulate the duel oracle",
+        enabledStrategies: ["retail", "market_maker", "oracle_attack"],
+        defaultTicks: 18,
+        defaultWinner: "A",
+        canonicalSeed: "oracle-attack-seed-1",
+        matrixSeeds: [],
+        tier: "diagnostic",
+    },
+    {
+        id: "cabal-coordination",
+        name: "Cabal Coordination",
+        family: "coordinated-flow",
+        description: "Two coordinated cabal groups betting against each other",
+        enabledStrategies: ["retail", "market_maker", "cabal"],
+        defaultTicks: 18,
+        defaultWinner: "B",
+        canonicalSeed: "cabal-coordination-seed-1",
+        matrixSeeds: [],
+        tier: "diagnostic",
+    },
+    {
+        id: "arbitrage-hunt",
+        name: "Arbitrage Hunt",
+        family: "crossed-book-arbitrage",
+        description: "Arbitrageur exploiting tight or crossed spreads",
+        enabledStrategies: ["retail", "market_maker", "arbitrageur"],
+        defaultTicks: 8,
+        defaultWinner: "A",
+        canonicalSeed: "crossed-book-seed-1",
+        matrixSeeds: [],
+        tier: "gate",
+        gatePolicy: {
+            requireDegradationFree: true,
+            requireMmSolvent: true,
+            requireBookIntegrity: true,
+            maxAttackerPnl: 0,
+        },
+    },
+    {
+        id: "cancel-replace-griefing",
+        name: "Cancel Replace Griefing",
+        family: "cancel-replace-griefing",
+        description: "Attacker churns orders to stress quote refresh and order cleanup",
+        enabledStrategies: ["retail", "market_maker", "cancel_replace"],
+        defaultTicks: 8,
+        defaultWinner: "B",
+        canonicalSeed: "cancel-replace-seed-1",
+        matrixSeeds: [],
+        tier: "gate",
+        gatePolicy: {
+            requireDegradationFree: true,
+            requireMmSolvent: true,
+            requireBookIntegrity: true,
+            maxAttackerPnl: 0,
+            maxOrderChurn: 120,
+        },
+    },
+    {
+        id: "stress-test",
+        name: "Stress Test",
+        family: "order-flood-dos",
+        description: "High-frequency flood of orders overwhelming the book",
+        enabledStrategies: ["retail", "market_maker", "stress_test"],
+        defaultTicks: 6,
+        defaultWinner: "B",
+        canonicalSeed: "order-flood-seed-1",
+        matrixSeeds: ["order-flood-seed-2", "order-flood-seed-3"],
+        tier: "gate",
+        gatePolicy: {
+            requireDegradationFree: true,
+            requireMmSolvent: true,
+            requireBookIntegrity: true,
+            maxAttackerPnl: 0,
+            maxDrawdownBps: 2_000,
+            maxOrderChurn: 160,
+        },
+    },
+    {
+        id: "whale-vs-mev",
+        name: "Whale vs MEV",
+        family: "toxic-flow",
+        description: "Whale moving markets while MEV bots try to extract",
+        enabledStrategies: ["market_maker", "whale", "mev_frontrunner"],
+        defaultTicks: 20,
+        defaultWinner: "B",
+        canonicalSeed: "whale-vs-mev-seed-1",
+        matrixSeeds: [],
+        tier: "diagnostic",
+    },
+    {
+        id: "claim-refund-abuse",
+        name: "Claim Refund Abuse",
+        family: "claim-refund-abuse",
+        description: "Cancelled market exercises refund cleanup and repeated claim safety",
+        enabledStrategies: ["market_maker", "whale"],
+        defaultTicks: 4,
+        defaultWinner: "B",
+        canonicalSeed: "claim-refund-seed-1",
+        matrixSeeds: [],
+        tier: "gate",
+        runtimeProfile: {
+            settlementMode: "cancel",
+        },
+        gatePolicy: {
+            requireDegradationFree: true,
+            requireMmSolvent: true,
+            requireBookIntegrity: true,
+            requireSettlementConsistency: true,
+            requireClaimsProcessed: true,
+            expectedSettlementStatus: "CANCELLED",
+            maxAttackerPnl: 0,
+        },
+    },
+    {
+        id: "attack-gauntlet",
+        name: "Attack Gauntlet",
+        family: "multi-vector",
+        description: "All attack agents vs thin MM — maximum adversarial pressure",
+        enabledStrategies: [
+            "market_maker",
+            "mev_frontrunner",
+            "sandwich",
+            "wash_trader",
+            "cabal",
+            "arbitrageur",
+        ],
+        defaultTicks: 10,
+        defaultWinner: "B",
+        canonicalSeed: "gauntlet-seed-1",
+        matrixSeeds: [],
+        tier: "diagnostic",
+    },
+    {
+        id: "liquidity-crisis",
+        name: "Liquidity Crisis",
+        family: "insolvency",
+        description: "Only the underfunded MM and whale — tests insolvency edge cases",
+        enabledStrategies: ["market_maker", "whale"],
+        defaultTicks: 18,
+        defaultWinner: "B",
+        canonicalSeed: "liquidity-crisis-seed-1",
+        matrixSeeds: [],
+        tier: "diagnostic",
+    },
+    {
+        id: "full-chaos",
+        name: "Full Chaos",
+        family: "multi-vector",
+        description: "All agents active simultaneously — maximum entropy",
+        enabledStrategies: [
+            "retail",
+            "market_maker",
+            "whale",
+            "mev_frontrunner",
+            "sandwich",
+            "wash_trader",
+            "oracle_attack",
+            "cabal",
+            "arbitrageur",
+            "stress_test",
+            "cancel_replace",
+        ],
+        defaultTicks: 8,
+        defaultWinner: "B",
+        canonicalSeed: "chaos-seed-1",
+        matrixSeeds: [],
+        tier: "diagnostic",
+    },
+];
+
+export const GATE_SCENARIOS = SCENARIO_PRESETS.filter(
+    (scenario) => scenario.tier === "gate",
+);
+
+export function getScenarioPresetByIdOrName(
+    nameOrId: string,
+): ScenarioPreset | null {
+    return (
+        SCENARIO_PRESETS.find(
+            (entry) => entry.id === nameOrId || entry.name === nameOrId,
+        ) ?? null
+    );
+}

--- a/packages/simulation-dashboard/src/scenario-evaluator.test.ts
+++ b/packages/simulation-dashboard/src/scenario-evaluator.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+    GATE_SCENARIOS,
+    getScenarioPresetByIdOrName,
+} from "./scenario-catalog.js";
+import { evaluateScenarioPolicyGates } from "./scenario-evaluator.js";
+
+describe("scenario catalog", () => {
+    it("exposes all required gate families", () => {
+        const families = new Set(GATE_SCENARIOS.map((scenario) => scenario.family));
+        expect(families.has("stale-signal-sniping")).toBeTrue();
+        expect(families.has("stale-oracle-sniping")).toBeTrue();
+        expect(families.has("close-window-race")).toBeTrue();
+        expect(families.has("crossed-book-arbitrage")).toBeTrue();
+        expect(families.has("sandwich")).toBeTrue();
+        expect(families.has("frontrun-backrun")).toBeTrue();
+        expect(families.has("wash-self-trade")).toBeTrue();
+        expect(families.has("cancel-replace-griefing")).toBeTrue();
+        expect(families.has("order-flood-dos")).toBeTrue();
+        expect(families.has("inventory-poisoning")).toBeTrue();
+        expect(families.has("claim-refund-abuse")).toBeTrue();
+    });
+});
+
+describe("evaluateScenarioPolicyGates", () => {
+    it("enforces stale signal guard policy", () => {
+        const preset = getScenarioPresetByIdOrName("stale-signal-sniping");
+        expect(preset).not.toBeNull();
+        const gates = evaluateScenarioPolicyGates(preset!, {
+            attackerPnl: 0,
+            maxDrawdownBps: 0,
+            quoteUptimeRatio: 0,
+            orderChurn: 0,
+            degraded: false,
+            mmSolvent: true,
+            bookNotCrossed: true,
+            settlementConsistent: true,
+            claimsProcessed: true,
+            settlementStatus: "OPEN",
+            staleStreamGuardTrips: 1,
+            staleOracleGuardTrips: 0,
+            closeGuardTrips: 0,
+        });
+        expect(gates.every((gate) => gate.passed)).toBeTrue();
+    });
+
+    it("flags missing refund cleanup on cancel scenarios", () => {
+        const preset = getScenarioPresetByIdOrName("claim-refund-abuse");
+        expect(preset).not.toBeNull();
+        const gates = evaluateScenarioPolicyGates(preset!, {
+            attackerPnl: 0,
+            maxDrawdownBps: 0,
+            quoteUptimeRatio: 0.5,
+            orderChurn: 20,
+            degraded: false,
+            mmSolvent: true,
+            bookNotCrossed: true,
+            settlementConsistent: true,
+            claimsProcessed: false,
+            settlementStatus: "CANCELLED",
+            staleStreamGuardTrips: 0,
+            staleOracleGuardTrips: 0,
+            closeGuardTrips: 0,
+        });
+        expect(gates.some((gate) => gate.name === "scenarioClaimsProcessed" && !gate.passed)).toBeTrue();
+    });
+});

--- a/packages/simulation-dashboard/src/scenario-evaluator.ts
+++ b/packages/simulation-dashboard/src/scenario-evaluator.ts
@@ -1,0 +1,163 @@
+import type { MitigationGate } from "@hyperbet/mm-core";
+
+import type {
+    ScenarioGatePolicy,
+    ScenarioPreset,
+    ScenarioSettlementStatus,
+} from "./scenario-catalog.js";
+
+export type ScenarioEvaluationMetrics = {
+    attackerPnl: number;
+    maxDrawdownBps: number;
+    quoteUptimeRatio: number;
+    orderChurn: number;
+    degraded: boolean;
+    mmSolvent: boolean;
+    bookNotCrossed: boolean;
+    settlementConsistent: boolean;
+    claimsProcessed: boolean;
+    settlementStatus: ScenarioSettlementStatus;
+    staleStreamGuardTrips: number;
+    staleOracleGuardTrips: number;
+    closeGuardTrips: number;
+};
+
+function pushPolicyGate(
+    gates: MitigationGate[],
+    name: string,
+    passed: boolean,
+    reason: string | null,
+): void {
+    gates.push({
+        name,
+        passed,
+        reason: passed ? null : reason,
+    });
+}
+
+export function evaluateScenarioPolicyGates(
+    preset: ScenarioPreset,
+    metrics: ScenarioEvaluationMetrics,
+): MitigationGate[] {
+    const policy: ScenarioGatePolicy | undefined = preset.gatePolicy;
+    if (!policy) {
+        return [];
+    }
+
+    const gates: MitigationGate[] = [];
+
+    if (policy.requireDegradationFree) {
+        pushPolicyGate(
+            gates,
+            "degradationFree",
+            !metrics.degraded,
+            "scenario required a degraded completion path",
+        );
+    }
+    if (policy.requireMmSolvent) {
+        pushPolicyGate(
+            gates,
+            "scenarioMmSolvent",
+            metrics.mmSolvent,
+            "market-maker wallet depleted during scenario",
+        );
+    }
+    if (policy.requireBookIntegrity) {
+        pushPolicyGate(
+            gates,
+            "scenarioBookIntegrity",
+            metrics.bookNotCrossed,
+            "crossed book observed during scenario",
+        );
+    }
+    if (policy.requireStaleStreamGuard) {
+        pushPolicyGate(
+            gates,
+            "staleStreamGuardTriggered",
+            metrics.staleStreamGuardTrips > 0,
+            "stale stream guard never triggered",
+        );
+    }
+    if (policy.requireStaleOracleGuard) {
+        pushPolicyGate(
+            gates,
+            "staleOracleGuardTriggered",
+            metrics.staleOracleGuardTrips > 0,
+            "stale oracle guard never triggered",
+        );
+    }
+    if (policy.requireCloseGuard) {
+        pushPolicyGate(
+            gates,
+            "closeGuardTriggered",
+            metrics.closeGuardTrips > 0,
+            "bet close guard never triggered",
+        );
+    }
+    if (policy.requireSettlementConsistency) {
+        pushPolicyGate(
+            gates,
+            "scenarioSettlementConsistent",
+            metrics.settlementConsistent,
+            "settlement outcome was inconsistent with market state",
+        );
+    }
+    if (policy.requireClaimsProcessed) {
+        pushPolicyGate(
+            gates,
+            "scenarioClaimsProcessed",
+            metrics.claimsProcessed,
+            "settled market retained claimable or uncleared positions",
+        );
+    }
+    if (policy.expectedSettlementStatus) {
+        pushPolicyGate(
+            gates,
+            "expectedSettlementObserved",
+            metrics.settlementStatus === policy.expectedSettlementStatus,
+            `expected ${policy.expectedSettlementStatus.toLowerCase()} but observed ${metrics.settlementStatus.toLowerCase()}`,
+        );
+    }
+    if (policy.maxAttackerPnl != null) {
+        pushPolicyGate(
+            gates,
+            "attackerEdgeBounded",
+            metrics.attackerPnl <= policy.maxAttackerPnl,
+            `attacker pnl peaked at ${metrics.attackerPnl.toFixed(4)} ETH`,
+        );
+    }
+    if (policy.maxDrawdownBps != null) {
+        pushPolicyGate(
+            gates,
+            "drawdownBounded",
+            metrics.maxDrawdownBps <= policy.maxDrawdownBps,
+            `market-maker drawdown reached ${metrics.maxDrawdownBps} bps`,
+        );
+    }
+    if (policy.minQuoteUptimeRatio != null) {
+        pushPolicyGate(
+            gates,
+            "quoteUptimeFloor",
+            metrics.quoteUptimeRatio >= policy.minQuoteUptimeRatio,
+            `quote uptime ratio fell to ${metrics.quoteUptimeRatio.toFixed(3)}`,
+        );
+    }
+    if (policy.maxQuoteUptimeRatio != null) {
+        pushPolicyGate(
+            gates,
+            "quoteUptimeCap",
+            metrics.quoteUptimeRatio <= policy.maxQuoteUptimeRatio,
+            `quote uptime ratio stayed too high at ${metrics.quoteUptimeRatio.toFixed(3)}`,
+        );
+    }
+    if (policy.maxOrderChurn != null) {
+        pushPolicyGate(
+            gates,
+            "orderChurnBounded",
+            metrics.orderChurn <= policy.maxOrderChurn,
+            `order churn reached ${metrics.orderChurn}`,
+        );
+    }
+
+    return gates;
+}

--- a/packages/simulation-dashboard/src/server.ts
+++ b/packages/simulation-dashboard/src/server.ts
@@ -1,17 +1,27 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import { readFileSync, existsSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, dirname, extname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { ContractFactory, JsonRpcProvider, ethers, type Contract } from "ethers";
 import { WebSocketServer, WebSocket } from "ws";
+import {
+    computeToxicityBps,
+    type AgentActionTrace,
+    type MitigationGate,
+    type ScenarioResult,
+} from "@hyperbet/mm-core";
 
 import {
     loadArtifact,
     duelKey,
     hashParticipant,
     sleep,
+    random,
+    setRandomSeed,
+    resetRandomSource,
     MARKET_KIND_DUEL_WINNER,
     DUEL_STATUS_BETTING_OPEN,
     SIDE_A,
@@ -21,6 +31,7 @@ import {
     MAX_PRICE,
     shortAddr,
     formatEth,
+    withTimeout,
 } from "./helpers.js";
 
 import {
@@ -35,9 +46,18 @@ import {
     CabalAgent,
     ArbitrageurAgent,
     StressTestAgent,
-    SCENARIO_PRESETS,
+    CancelReplaceAgent,
     type SimContext,
 } from "./agents.js";
+import {
+    GATE_SCENARIOS,
+    SCENARIO_PRESETS,
+    getScenarioPresetByIdOrName,
+    type ScenarioPreset,
+    type ScenarioSettlementMode,
+    type ScenarioSettlementStatus,
+} from "./scenario-catalog.js";
+import { evaluateScenarioPolicyGates } from "./scenario-evaluator.js";
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 const __filename = fileURLToPath(import.meta.url);
@@ -47,12 +67,77 @@ const WS_PORT = 3400;
 const HTTP_PORT = 3401;
 const PUBLIC_DIR = join(__dirname, "..", "public");
 const CONTRACTS_DIR = join(__dirname, "..", "..", "evm-contracts");
+const SCENARIO_HISTORY_LIMIT = 50;
+const SCENARIO_HISTORY_PATH =
+    process.env.SIM_SCENARIO_HISTORY_PATH?.trim() ||
+    join(tmpdir(), "hyperbet", "simulation-dashboard-history.json");
+const RESOLVE_CLAIM_BUDGET_MS = Number(
+    process.env.SIM_RESOLVE_CLAIM_BUDGET_MS ?? "45000",
+);
+const SCENARIO_RESOLVE_TIMEOUT_MS = Number(
+    process.env.SIM_SCENARIO_RESOLVE_TIMEOUT_MS ?? "120000",
+);
+const SCENARIO_SETTLEMENT_TX_TIMEOUT_MS = Number(
+    process.env.SIM_SCENARIO_SETTLEMENT_TX_TIMEOUT_MS ?? "20000",
+);
+const SCENARIO_SETTLEMENT_RECEIPT_TIMEOUT_MS = Number(
+    process.env.SIM_SCENARIO_SETTLEMENT_RECEIPT_TIMEOUT_MS ?? "30000",
+);
+const SCENARIO_BASELINE_REVERT_TIMEOUT_MS = Number(
+    process.env.SIM_SCENARIO_BASELINE_REVERT_TIMEOUT_MS ?? "12000",
+);
+const SCENARIO_BASELINE_SNAPSHOT_TIMEOUT_MS = Number(
+    process.env.SIM_SCENARIO_BASELINE_SNAPSHOT_TIMEOUT_MS ?? "12000",
+);
+const SCENARIO_BASELINE_REBUILD_TIMEOUT_MS = Number(
+    process.env.SIM_SCENARIO_BASELINE_REBUILD_TIMEOUT_MS ?? "90000",
+);
+
+type ScenarioRunStatus = "queued" | "running" | "succeeded" | "failed";
+
+type ScenarioRunRecord = {
+    runId: string;
+    scenarioId: string;
+    scenarioName: string;
+    seed: string;
+    ticks: number;
+    winner: "A" | "B";
+    freshBaseline: boolean;
+    status: ScenarioRunStatus;
+    stage: string | null;
+    requestedAt: number;
+    startedAt: number | null;
+    finishedAt: number | null;
+    error: string | null;
+    result: ScenarioResult | null;
+};
+
+type PersistedScenarioState = {
+    history: ScenarioResult[];
+    runs: ScenarioRunRecord[];
+};
+
+type CachedPosition = {
+    aShares: bigint;
+    bShares: bigint;
+    aStake: bigint;
+    bStake: bigint;
+};
+
+type ClaimCandidate = {
+    agent: BaseAgent;
+    address: string;
+    position: CachedPosition;
+};
 
 // ─── State ───────────────────────────────────────────────────────────────────
 let anvilProcess: ChildProcess | null = null;
 let provider: JsonRpcProvider;
+let readProvider: JsonRpcProvider;
 let oracle: Contract;
+let oracleRead: Contract;
 let clob: Contract;
+let clobRead: Contract;
 let agents: BaseAgent[] = [];
 let simRunning = false;
 let simSpeed = 500; // ms between ticks
@@ -61,11 +146,513 @@ let currentDuelKey = "";
 let currentMarketKey = "";
 let currentDuelLabel = "";
 let duelCounter = 0;
+let currentScenarioId = "manual";
 let treasuryAddr = "";
 let mmAddr = "";
+let oracleAddr = "";
+let clobAddr = "";
+let feeConfig = {
+    treasuryBps: 0n,
+    mmBps: 0n,
+    winningsMmBps: 0n,
+};
 const eventLog: any[] = [];
 const initialBalances: Map<string, string> = new Map();
 const wsClients = new Set<WebSocket>();
+const ATTACKER_STRATEGIES = new Set([
+    "mev_frontrunner",
+    "sandwich",
+    "wash_trader",
+    "oracle_attack",
+    "cabal",
+    "arbitrageur",
+    "stress_test",
+    "cancel_replace",
+]);
+const MARKET_STATUS_RESOLVED = 3;
+const MARKET_STATUS_CANCELLED = 4;
+let peakInventorySeen = 0;
+let worstMarketMakerPnl = 0;
+let bestAttackerPnlSeen = 0;
+let scenarioObservedTicks = 0;
+let scenarioQuotedTicks = 0;
+let scenarioSpreadBpsTotal = 0;
+let scenarioSpreadSamples = 0;
+let lastResolveLatencyMs: number | null = null;
+let staleStreamGuardTripsSeen = 0;
+let staleOracleGuardTripsSeen = 0;
+let closeGuardTripsSeen = 0;
+let circuitBreakerTripsSeen = 0;
+let lastComputedState: Record<string, any> | null = null;
+let scenarioRunInFlight = false;
+let scenarioHistory: ScenarioResult[] = [];
+let scenarioRuns: ScenarioRunRecord[] = [];
+let activeScenarioRunId: string | null = null;
+let scenarioRunSequence = 0;
+let baselineSnapshotId: string | null = null;
+let baselineRuntimeState:
+    | {
+          duelCounter: number;
+          currentDuelLabel: string;
+          currentDuelKey: string;
+          currentMarketKey: string;
+      }
+    | null = null;
+const agentAddressCache = new Map<BaseAgent, string>();
+const agentPositionCache = new Map<string, CachedPosition>();
+const ZERO_POSITION: CachedPosition = {
+    aShares: 0n,
+    bShares: 0n,
+    aStake: 0n,
+    bStake: 0n,
+};
+
+function loadScenarioState(): void {
+    if (!existsSync(SCENARIO_HISTORY_PATH)) {
+        return;
+    }
+    try {
+        const parsed = JSON.parse(
+            readFileSync(SCENARIO_HISTORY_PATH, "utf8"),
+        ) as Partial<PersistedScenarioState>;
+        scenarioHistory = Array.isArray(parsed.history)
+            ? parsed.history.slice(0, SCENARIO_HISTORY_LIMIT)
+            : [];
+        scenarioRuns = Array.isArray(parsed.runs)
+            ? parsed.runs.slice(0, SCENARIO_HISTORY_LIMIT)
+            : [];
+    } catch (error) {
+        console.warn(
+            `[history] Failed to load ${SCENARIO_HISTORY_PATH}: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+    }
+}
+
+function persistScenarioState(): void {
+    try {
+        mkdirSync(dirname(SCENARIO_HISTORY_PATH), { recursive: true });
+        writeFileSync(
+            SCENARIO_HISTORY_PATH,
+            JSON.stringify(
+                {
+                    history: scenarioHistory.slice(0, SCENARIO_HISTORY_LIMIT),
+                    runs: scenarioRuns.slice(0, SCENARIO_HISTORY_LIMIT),
+                } satisfies PersistedScenarioState,
+                null,
+                2,
+            ),
+            "utf8",
+        );
+    } catch (error) {
+        console.warn(
+            `[history] Failed to persist ${SCENARIO_HISTORY_PATH}: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+    }
+}
+
+function getActiveScenarioRun(): ScenarioRunRecord | null {
+    if (!activeScenarioRunId) {
+        return null;
+    }
+    return scenarioRuns.find((run) => run.runId === activeScenarioRunId) ?? null;
+}
+
+function updateScenarioRun(
+    runId: string,
+    mutator: (run: ScenarioRunRecord) => void,
+): ScenarioRunRecord | null {
+    const run = scenarioRuns.find((entry) => entry.runId === runId) ?? null;
+    if (!run) {
+        return null;
+    }
+    mutator(run);
+    persistScenarioState();
+    return run;
+}
+
+function countEnabledAgents(): number {
+    return agents.reduce(
+        (count, agent) => count + (agent.config.enabled ? 1 : 0),
+        0,
+    );
+}
+
+async function getAgentAddress(agent: BaseAgent): Promise<string> {
+    const cached = agentAddressCache.get(agent);
+    if (cached) {
+        return cached;
+    }
+    const address = await agent.signer.getAddress();
+    agentAddressCache.set(agent, address);
+    return address;
+}
+
+function getCachedPosition(address: string): CachedPosition {
+    return agentPositionCache.get(address) ?? ZERO_POSITION;
+}
+
+function hasPosition(position: CachedPosition): boolean {
+    return (
+        position.aShares > 0n ||
+        position.bShares > 0n ||
+        position.aStake > 0n ||
+        position.bStake > 0n
+    );
+}
+
+function parsePosition(positionRaw: {
+    aShares: bigint;
+    bShares: bigint;
+    aStake: bigint;
+    bStake: bigint;
+}): CachedPosition {
+    return {
+        aShares: BigInt(positionRaw.aShares),
+        bShares: BigInt(positionRaw.bShares),
+        aStake: BigInt(positionRaw.aStake),
+        bStake: BigInt(positionRaw.bStake),
+    };
+}
+
+function updateActiveRunStage(stage: string): void {
+    const activeRun = getActiveScenarioRun();
+    if (!activeRun) {
+        return;
+    }
+    updateScenarioRun(activeRun.runId, (entry) => {
+        entry.stage = stage;
+    });
+}
+
+function refreshReadClients(): void {
+    readProvider = new JsonRpcProvider(`http://127.0.0.1:${ANVIL_PORT}`, 31337);
+    if (oracle) {
+        oracleRead = oracle.connect(readProvider) as unknown as Contract;
+    }
+    if (clob) {
+        clobRead = clob.connect(readProvider) as unknown as Contract;
+    }
+}
+
+async function withReadRetry<T>(
+    label: string,
+    load: () => Promise<T>,
+    options: {
+        attempts?: number;
+        timeoutMs?: number;
+        backoffMs?: number;
+    } = {},
+): Promise<T> {
+    const attempts = Math.max(1, options.attempts ?? 2);
+    const timeoutMs = Math.max(2_000, options.timeoutMs ?? 12_000);
+    const backoffMs = Math.max(10, options.backoffMs ?? 100);
+    let lastError: unknown = null;
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            return await withTimeout(
+                load(),
+                timeoutMs,
+                `${label} attempt ${attempt}`,
+            );
+        } catch (error) {
+            lastError = error;
+            if (attempt < attempts) {
+                refreshReadClients();
+                await sleep(backoffMs * attempt);
+            }
+        }
+    }
+
+    throw lastError instanceof Error
+        ? lastError
+        : new Error(`${label} failed after ${attempts} attempts`);
+}
+
+async function loadClaimPosition(
+    agent: BaseAgent,
+    address: string,
+): Promise<CachedPosition | null> {
+    const cachedPosition = getCachedPosition(address);
+    if (hasPosition(cachedPosition)) {
+        return cachedPosition;
+    }
+
+    const loadWithContract = async (
+        contract: Contract,
+        label: string,
+    ): Promise<CachedPosition> => {
+        const positionRaw = await withTimeout(
+            contract.positions(currentMarketKey, address),
+            6_000,
+            `${agent.config.name} ${label} claim lookup`,
+        );
+        return parsePosition(positionRaw);
+    };
+
+    try {
+        const position = await loadWithContract(clobRead, "read");
+        agentPositionCache.set(address, position);
+        return position;
+    } catch (error) {
+        refreshReadClients();
+        try {
+            const position = await loadWithContract(clob, "write");
+            agentPositionCache.set(address, position);
+            return position;
+        } catch (fallbackError) {
+            broadcast({
+                type: "log",
+                data: {
+                    message: `[${agent.config.name}] Claim lookup skipped: ${
+                        fallbackError instanceof Error
+                            ? fallbackError.message.slice(0, 100)
+                            : String(fallbackError).slice(0, 100)
+                    }`,
+                    tick: simTick,
+                },
+            });
+            if (error instanceof Error) {
+                console.warn(
+                    `[claims] ${agent.config.name} read lookup failed: ${error.message}`,
+                );
+            }
+            return null;
+        }
+    }
+}
+
+function getResidualClaimCandidates(): ClaimCandidate[] {
+    const candidates: ClaimCandidate[] = [];
+    for (const agent of agents) {
+        const address = agentAddressCache.get(agent);
+        if (!address) {
+            continue;
+        }
+        const position = getCachedPosition(address);
+        if (!hasPosition(position)) {
+            continue;
+        }
+        candidates.push({
+            agent,
+            address,
+            position,
+        });
+    }
+    return candidates;
+}
+
+async function processClaimCandidates(
+    candidates: ClaimCandidate[],
+    stagePrefix: string,
+    budgetMs: number,
+): Promise<void> {
+    if (candidates.length === 0) {
+        return;
+    }
+
+    updateActiveRunStage(`${stagePrefix}-${candidates.length}`);
+    const claimDeadline = Date.now() + budgetMs;
+    for (const [index, candidate] of candidates.entries()) {
+        if (Date.now() >= claimDeadline) {
+            updateActiveRunStage(`${stagePrefix}-budget-exhausted`);
+            broadcast({
+                type: "log",
+                data: {
+                    message: `⏭️ Claim budget exhausted after ${index}/${candidates.length} claims during ${stagePrefix}`,
+                    tick: simTick,
+                },
+            });
+            break;
+        }
+        try {
+            updateActiveRunStage(
+                `${stagePrefix}-${index + 1}-of-${candidates.length}`,
+            );
+            const txClaim: any = await withTimeout(
+                (clob.connect(candidate.agent.signer) as any).claim(
+                    currentDuelKey,
+                    MARKET_KIND_DUEL_WINNER,
+                ),
+                20_000,
+                `${candidate.agent.config.name} claim`,
+            );
+            await withTimeout(
+                txClaim.wait(),
+                20_000,
+                `${candidate.agent.config.name} claim receipt`,
+            );
+            agentPositionCache.set(candidate.address, { ...ZERO_POSITION });
+            broadcast({
+                type: "log",
+                data: {
+                    message: `[${candidate.agent.config.name}] Claimed winnings`,
+                    tick: simTick,
+                },
+            });
+        } catch (err: any) {
+            broadcast({
+                type: "log",
+                data: {
+                    message: `[${candidate.agent.config.name}] Claim: ${err.message?.slice(0, 80)}`,
+                    tick: simTick,
+                },
+            });
+        }
+    }
+}
+
+function createScenarioRunRecord(
+    preset: ScenarioPreset,
+    options: {
+        seed?: string;
+        ticks?: number;
+        winner?: "A" | "B";
+        freshBaseline?: boolean;
+    },
+): ScenarioRunRecord {
+    scenarioRunSequence += 1;
+    return {
+        runId: `${preset.id}-${Date.now()}-${scenarioRunSequence}`,
+        scenarioId: preset.id,
+        scenarioName: preset.name,
+        seed: options.seed?.trim() || preset.canonicalSeed,
+        ticks: Math.max(1, Math.min(200, options.ticks ?? preset.defaultTicks)),
+        winner: options.winner ?? preset.defaultWinner,
+        freshBaseline: options.freshBaseline ?? false,
+        status: "queued",
+        stage: "queued",
+        requestedAt: Date.now(),
+        startedAt: null,
+        finishedAt: null,
+        error: null,
+        result: null,
+    };
+}
+
+function resetScenarioMetrics(): void {
+    peakInventorySeen = 0;
+    worstMarketMakerPnl = 0;
+    bestAttackerPnlSeen = 0;
+    scenarioObservedTicks = 0;
+    scenarioQuotedTicks = 0;
+    scenarioSpreadBpsTotal = 0;
+    scenarioSpreadSamples = 0;
+    lastResolveLatencyMs = null;
+    staleStreamGuardTripsSeen = 0;
+    staleOracleGuardTripsSeen = 0;
+    closeGuardTripsSeen = 0;
+    circuitBreakerTripsSeen = 0;
+    lastComputedState = null;
+    simTick = 0;
+}
+
+function applyScenarioPresetByName(name: string): ScenarioPreset {
+    const preset = getScenarioPresetByIdOrName(name);
+    if (!preset) {
+        throw new Error(`Unknown scenario preset: ${name}`);
+    }
+
+    currentScenarioId = preset.id;
+    for (const agent of agents) {
+        agent.config.enabled = preset.enabledStrategies.includes(agent.config.strategy);
+    }
+    return preset;
+}
+
+function marketStatusLabel(status: number): ScenarioSettlementStatus {
+    switch (status) {
+        case 1:
+            return "OPEN";
+        case 2:
+            return "LOCKED";
+        case 3:
+            return "RESOLVED";
+        case 4:
+            return "CANCELLED";
+        default:
+            return "NULL";
+    }
+}
+
+async function restoreScenarioBaseline(): Promise<void> {
+    if (!provider || !baselineSnapshotId || !baselineRuntimeState) {
+        throw new Error("Scenario baseline is not initialized");
+    }
+
+    simRunning = false;
+    try {
+        updateActiveRunStage("restore-baseline-revert");
+        const controlProvider = new JsonRpcProvider(`http://127.0.0.1:${ANVIL_PORT}`, 31337);
+        await withTimeout(
+            controlProvider.send("evm_revert", [baselineSnapshotId]),
+            SCENARIO_BASELINE_REVERT_TIMEOUT_MS,
+            "baseline evm_revert",
+        );
+        updateActiveRunStage("restore-baseline-snapshot");
+        baselineSnapshotId = await withTimeout(
+            controlProvider.send("evm_snapshot", []),
+            SCENARIO_BASELINE_SNAPSHOT_TIMEOUT_MS,
+            "baseline evm_snapshot",
+        );
+        refreshReadClients();
+    } catch (error) {
+        console.warn(
+            `[baseline] Restore failed, rebuilding local sim backend: ${
+                error instanceof Error ? error.message : String(error)
+            }`,
+        );
+        updateActiveRunStage("restore-baseline-rebuild");
+        await withTimeout(
+            rebuildSimulationEnvironment(),
+            SCENARIO_BASELINE_REBUILD_TIMEOUT_MS,
+            "baseline rebuild",
+        );
+    }
+
+    duelCounter = baselineRuntimeState.duelCounter;
+    currentDuelLabel = baselineRuntimeState.currentDuelLabel;
+    currentDuelKey = baselineRuntimeState.currentDuelKey;
+    currentMarketKey = baselineRuntimeState.currentMarketKey;
+    currentScenarioId = "manual";
+    eventLog.length = 0;
+    for (const agent of agents) {
+        agent.activeOrderIds = [];
+        agent.tradeCount = 0;
+        const address = agentAddressCache.get(agent);
+        if (address) {
+            agentPositionCache.set(address, { ...ZERO_POSITION });
+        }
+    }
+    resetScenarioMetrics();
+}
+
+async function captureScenarioBaseline(): Promise<void> {
+    baselineRuntimeState = {
+        duelCounter,
+        currentDuelLabel,
+        currentDuelKey,
+        currentMarketKey,
+    };
+    baselineSnapshotId = await provider.send("evm_snapshot", []);
+    eventLog.length = 0;
+    refreshReadClients();
+}
+
+async function rebuildSimulationEnvironment(): Promise<void> {
+    await stopAnvil();
+    eventLog.length = 0;
+    initialBalances.clear();
+    agentAddressCache.clear();
+    agentPositionCache.clear();
+    await startAnvil();
+    await deployContracts();
+    await captureScenarioBaseline();
+}
 
 // ─── Anvil Management ────────────────────────────────────────────────────────
 
@@ -76,7 +663,7 @@ async function startAnvil(): Promise<void> {
             "--host", "127.0.0.1",
             "--port", String(ANVIL_PORT),
             "--chain-id", "31337",
-            "--accounts", "20",
+            "--accounts", "24",
             "--balance", "10000",
             "--silent",
         ]);
@@ -113,10 +700,30 @@ async function startAnvil(): Promise<void> {
     });
 }
 
-function stopAnvil(): void {
+async function stopAnvil(): Promise<void> {
     if (anvilProcess) {
-        anvilProcess.kill("SIGTERM");
+        const processToStop = anvilProcess;
         anvilProcess = null;
+        await new Promise<void>((resolve) => {
+            let settled = false;
+            const finish = () => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                resolve();
+            };
+            const timer = setTimeout(() => {
+                processToStop.kill("SIGKILL");
+                finish();
+            }, 5_000);
+            processToStop.once("exit", () => {
+                clearTimeout(timer);
+                finish();
+            });
+            processToStop.kill("SIGTERM");
+        });
+        await sleep(250);
         console.log("[anvil] Stopped");
     }
 }
@@ -125,9 +732,10 @@ function stopAnvil(): void {
 
 async function deployContracts(): Promise<void> {
     provider = new JsonRpcProvider(`http://127.0.0.1:${ANVIL_PORT}`, 31337);
+    readProvider = new JsonRpcProvider(`http://127.0.0.1:${ANVIL_PORT}`, 31337);
 
     const signers = await Promise.all(
-        Array.from({ length: 20 }, (_, i) => provider.getSigner(i)),
+        Array.from({ length: 24 }, (_, i) => provider.getSigner(i)),
     );
     const admin = signers[0];
     const operator = signers[1];
@@ -135,17 +743,21 @@ async function deployContracts(): Promise<void> {
     const treasury = signers[3];
     const marketMaker = signers[4];
 
-    // Compile contracts if needed
-    if (!existsSync(join(CONTRACTS_DIR, "artifacts", "contracts", "GoldClob.sol", "GoldClob.json"))) {
-        console.log("[deploy] Artifacts not found. Run `npx hardhat compile` in packages/evm-contracts first.");
-        process.exit(1);
-    }
-    
     treasuryAddr = await treasury.getAddress();
     mmAddr = await marketMaker.getAddress();
 
-    const oracleArtifact = loadArtifact(CONTRACTS_DIR, "DuelOutcomeOracle");
-    const clobArtifact = loadArtifact(CONTRACTS_DIR, "GoldClob");
+    let oracleArtifact;
+    let clobArtifact;
+    try {
+        oracleArtifact = loadArtifact(CONTRACTS_DIR, "DuelOutcomeOracle");
+        clobArtifact = loadArtifact(CONTRACTS_DIR, "GoldClob");
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.log(
+            `[deploy] Contract artifacts not found. Build packages/evm-contracts first. (${message})`,
+        );
+        process.exit(1);
+    }
 
     console.log("[deploy] Deploying DuelOutcomeOracle...");
     const oracleFactory = new ContractFactory(oracleArtifact.abi as any, oracleArtifact.bytecode, admin);
@@ -166,8 +778,15 @@ async function deployContracts(): Promise<void> {
     )) as unknown as Contract;
     await clob.waitForDeployment();
 
-    const oracleAddr = await oracle.getAddress();
-    const clobAddr = await clob.getAddress();
+    oracleAddr = await oracle.getAddress();
+    clobAddr = await clob.getAddress();
+    oracleRead = oracle.connect(readProvider) as unknown as Contract;
+    clobRead = clob.connect(readProvider) as unknown as Contract;
+    feeConfig = {
+        treasuryBps: BigInt(await clob.tradeTreasuryFeeBps()),
+        mmBps: BigInt(await clob.tradeMarketMakerFeeBps()),
+        winningsMmBps: BigInt(await clob.winningsMarketMakerFeeBps()),
+    };
     console.log(`[deploy] Oracle: ${oracleAddr}`);
     console.log(`[deploy] CLOB:   ${clobAddr}`);
 
@@ -234,6 +853,7 @@ async function createAgents(signers: any[]): Promise<void> {
         { agent: new CabalAgent(signers[19], clob, false), balance: "3" },
         { agent: new ArbitrageurAgent(signers[14], clob), balance: "2" },
         { agent: new StressTestAgent(signers[15], clob), balance: "2" },
+        { agent: new CancelReplaceAgent(signers[20], clob), balance: "2" },
     ];
 
     agents = agentDefs.map(d => d.agent);
@@ -253,6 +873,8 @@ async function createAgents(signers: any[]): Promise<void> {
     // Set balances via anvil_setBalance
     for (let i = 0; i < agents.length; i++) {
         const addr = await agents[i].signer.getAddress();
+        agentAddressCache.set(agents[i], addr);
+        agentPositionCache.set(addr, { ...ZERO_POSITION });
         const balWei = ethers.parseEther(agentDefs[i].balance);
         await provider.send("anvil_setBalance", [addr, "0x" + balWei.toString(16)]);
         initialBalances.set(addr, agentDefs[i].balance);
@@ -264,6 +886,8 @@ async function openNewDuel(): Promise<void> {
     duelCounter++;
     currentDuelLabel = `sim-duel-${duelCounter}`;
     currentDuelKey = duelKey(currentDuelLabel);
+    currentScenarioId = "manual";
+    resetScenarioMetrics();
 
     const reporter = await provider.getSigner(2);
     const operator = await provider.getSigner(1);
@@ -296,61 +920,98 @@ async function openNewDuel(): Promise<void> {
 
 async function simulationTick(): Promise<void> {
     simTick++;
+    const scenarioMode = scenarioRunInFlight;
+    const scenarioPreset = getScenarioPresetByIdOrName(currentScenarioId);
+    const treasuryFeeBps = feeConfig.treasuryBps;
+    const mmFeeBps = feeConfig.mmBps;
+    let market = await withReadRetry(
+        `tick ${simTick} initial getMarket`,
+        () => clobRead.getMarket(currentDuelKey, MARKET_KIND_DUEL_WINNER),
+    );
 
     for (const agent of agents) {
         if (!agent.config.enabled) continue;
 
+        if (scenarioMode) {
+            updateActiveRunStage(`tick-${simTick}-agent-${agent.config.strategy}`);
+        }
         try {
-            // Build context
-            const market = await clob.getMarket(currentDuelKey, MARKET_KIND_DUEL_WINNER);
-            const position = await clob.positions(currentMarketKey, await agent.signer.getAddress());
+            await withTimeout(
+                (async () => {
+                    const address = await getAgentAddress(agent);
+                    const position = getCachedPosition(address);
+                    const ctx: SimContext = {
+                        duelKey: currentDuelKey,
+                        marketKey: currentMarketKey,
+                        bestBid: Number(market.bestBid),
+                        bestAsk: Number(market.bestAsk) >= MAX_PRICE ? 0 : Number(market.bestAsk),
+                        mid: calculateMid(Number(market.bestBid), Number(market.bestAsk)),
+                        totalAShares: market.totalAShares,
+                        totalBShares: market.totalBShares,
+                        tick: simTick,
+                        nowMs: simTick * 500,
+                        treasuryFeeBps,
+                        mmFeeBps,
+                        agentActiveOrderIds: agent.activeOrderIds,
+                        scenarioProfile: scenarioPreset?.runtimeProfile ?? null,
+                        agentPosition: {
+                            aShares: position.aShares,
+                            bShares: position.bShares,
+                            aStake: position.aStake,
+                            bStake: position.bStake,
+                        },
+                    };
 
-            const ctx: SimContext = {
-                duelKey: currentDuelKey,
-                marketKey: currentMarketKey,
-                bestBid: Number(market.bestBid),
-                bestAsk: Number(market.bestAsk) >= MAX_PRICE ? 0 : Number(market.bestAsk),
-                mid: calculateMid(Number(market.bestBid), Number(market.bestAsk)),
-                totalAShares: market.totalAShares,
-                totalBShares: market.totalBShares,
-                tick: simTick,
-                treasuryFeeBps: await clob.tradeTreasuryFeeBps(),
-                mmFeeBps: await clob.tradeMarketMakerFeeBps(),
-                agentActiveOrderIds: agent.activeOrderIds,
-                agentPosition: {
-                    aShares: position.aShares,
-                    bShares: position.bShares,
-                    aStake: position.aStake,
-                    bStake: position.bStake,
-                },
-            };
+                    // Special handling for oracle attack agent
+                    if (agent instanceof OracleAttackAgent && agent.config.enabled) {
+                        if (simTick % 10 === 0) {
+                            const msg = await agent.executeOracleAttack(currentDuelKey);
+                            broadcast({ type: "log", data: { message: msg, tick: simTick } });
+                        }
+                        return;
+                    }
 
-            // Special handling for oracle attack agent
-            if (agent instanceof OracleAttackAgent && agent.config.enabled) {
-                if (simTick % 10 === 0) {
-                    const msg = await agent.executeOracleAttack(currentDuelKey);
-                    broadcast({ type: "log", data: { message: msg, tick: simTick } });
-                }
-                continue;
-            }
-
-            const actions = agent.decide(ctx);
-            if (actions.length > 0) {
-                const logs = await agent.executeActions(actions, ctx);
-                for (const msg of logs) {
-                    broadcast({ type: "log", data: { message: msg, tick: simTick } });
-                }
-            }
+                    const actions = agent.decide(ctx);
+                    if (actions.length > 0) {
+                        const logs = await withTimeout(
+                            agent.executeActions(actions, ctx),
+                            scenarioMode
+                                ? Math.max(8_000, actions.length * 6_000)
+                                : Math.max(20_000, actions.length * 20_000),
+                            `tick ${simTick} agent ${agent.config.name} executeActions`,
+                        );
+                        for (const msg of logs) {
+                            broadcast({ type: "log", data: { message: msg, tick: simTick } });
+                        }
+                    }
+                })(),
+                scenarioMode ? 15_000 : 120_000,
+                `tick ${simTick} agent ${agent.config.name}`,
+            );
         } catch (err: any) {
+            const message = err.message?.slice(0, 150) ?? "unknown simulation error";
             broadcast({
                 type: "log",
-                data: { message: `[${agent.config.name}] ERROR: ${err.message?.slice(0, 150)}`, tick: simTick },
+                data: { message: `[${agent.config.name}] ERROR: ${message}`, tick: simTick },
             });
+            if (message.includes("timed out after") && !scenarioMode) {
+                throw err;
+            }
         }
+
+        await sleep(5);
     }
 
-    // Broadcast full state update
-    await broadcastState();
+    if (scenarioRunInFlight) {
+        return;
+    }
+
+    // Broadcast full state update for interactive/manual mode.
+    await withTimeout(
+        broadcastState(),
+        30_000,
+        `tick ${simTick} broadcastState`,
+    );
 }
 
 function calculateMid(bestBid: number, bestAsk: number): number {
@@ -365,44 +1026,222 @@ function calculateMid(bestBid: number, bestAsk: number): number {
 
 async function broadcastState(): Promise<void> {
     try {
-        const market = await clob.getMarket(currentDuelKey, MARKET_KIND_DUEL_WINNER);
+        const [
+            market,
+            agentSnapshots,
+            book,
+            treasuryBalance,
+            mmBalance,
+        ] = await Promise.all([
+            withReadRetry(
+                "broadcast getMarket",
+                () => clobRead.getMarket(currentDuelKey, MARKET_KIND_DUEL_WINNER),
+            ),
+            Promise.all(
+                agents.map(async (agent) => {
+                    const addr = await getAgentAddress(agent);
+                    const [balance, position] = await Promise.all([
+                        withReadRetry(
+                            `broadcast ${agent.config.name} getBalance`,
+                            () => readProvider.getBalance(addr),
+                        ),
+                        withReadRetry(
+                            `broadcast ${agent.config.name} getPosition`,
+                            () => clobRead.positions(currentMarketKey, addr),
+                        ),
+                    ]);
+                    const balanceFormatted = formatEth(balance);
+                    const initBal = initialBalances.get(addr) || "10000";
+                    const pnlValue = Number(balanceFormatted) - Number(initBal);
+                    const inventoryUnits = Number(position.aShares + position.bShares);
+                    return {
+                        name: agent.config.name,
+                        strategy: agent.config.strategy,
+                        description: agent.config.description,
+                        enabled: agent.config.enabled,
+                        color: agent.config.color,
+                        address: addr,
+                        balance: balanceFormatted,
+                        pnl: pnlValue.toFixed(4),
+                        pnlValue,
+                        tradeCount: agent.tradeCount,
+                        activeOrders: agent.activeOrderIds.length,
+                        inventoryUnits,
+                        positionRaw: {
+                            aShares: position.aShares.toString(),
+                            bShares: position.bShares.toString(),
+                            aStake: position.aStake.toString(),
+                            bStake: position.bStake.toString(),
+                        },
+                        position: {
+                            aShares: position.aShares.toString(),
+                            bShares: position.bShares.toString(),
+                            aStake: formatEth(position.aStake),
+                            bStake: formatEth(position.bStake),
+                        },
+                        };
+                    }),
+            ),
+            buildOrderBook(),
+            withReadRetry("broadcast treasury getBalance", () => readProvider.getBalance(treasuryAddr)),
+            withReadRetry("broadcast mm getBalance", () => readProvider.getBalance(mmAddr)),
+        ]);
+        for (const snapshot of agentSnapshots) {
+            agentPositionCache.set(snapshot.address, {
+                aShares: BigInt(snapshot.positionRaw.aShares),
+                bShares: BigInt(snapshot.positionRaw.bShares),
+                aStake: BigInt(snapshot.positionRaw.aStake),
+                bStake: BigInt(snapshot.positionRaw.bStake),
+            });
+        }
+        const agentStates = agentSnapshots.map(
+            ({ pnlValue, inventoryUnits, positionRaw, ...agentState }) => agentState,
+        );
+        const marketStatus = Number(market.status);
+        const settlementStatus = marketStatusLabel(marketStatus);
+        const bestBid = Number(market.bestBid);
+        const bestAsk = Number(market.bestAsk);
+        const boundedBestAsk = bestAsk > 0 && bestAsk < MAX_PRICE ? bestAsk : null;
+        const spreadWidthBps = computeToxicityBps(
+            bestBid > 0 ? bestBid : null,
+            boundedBestAsk,
+        );
+        const orderChurn = eventLog.filter((entry) =>
+            entry.event === "OrderPlaced" ||
+            entry.event === "OrderCancelled" ||
+            entry.event === "OrderMatched",
+        ).length;
+        const attackerPnl = agentSnapshots
+            .filter((agent) => ATTACKER_STRATEGIES.has(agent.strategy))
+            .reduce((max, agent) => Math.max(max, agent.pnlValue), 0);
+        bestAttackerPnlSeen = Math.max(bestAttackerPnlSeen, attackerPnl);
 
-        // Gather agent states
-        const agentStates = await Promise.all(
-            agents.map(async (agent) => {
-                const addr = await agent.signer.getAddress();
-                const balance = await provider.getBalance(addr);
-                const position = await clob.positions(currentMarketKey, addr);
-                const balanceFormatted = formatEth(balance);
-                const initBal = initialBalances.get(addr) || "10000";
-                const pnl = (Number(balanceFormatted) - Number(initBal)).toFixed(4);
-
-                return {
-                    name: agent.config.name,
-                    strategy: agent.config.strategy,
-                    description: agent.config.description,
-                    enabled: agent.config.enabled,
-                    color: agent.config.color,
-                    address: addr,
-                    balance: balanceFormatted,
-                    pnl,
-                    tradeCount: agent.tradeCount,
-                    activeOrders: agent.activeOrderIds.length,
-                    position: {
-                        aShares: position.aShares.toString(),
-                        bShares: position.bShares.toString(),
-                        aStake: formatEth(position.aStake),
-                        bStake: formatEth(position.bStake),
-                    },
-                };
-            }),
+        const marketMakerAgent = agentSnapshots.find(
+            (agent) => agent.strategy === "market_maker",
+        );
+        const marketMakerRuntimeAgent =
+            agents.find((agent) => agent instanceof MarketMakerAgent) ??
+            null;
+        const marketMakerPlan =
+            marketMakerRuntimeAgent instanceof MarketMakerAgent
+                ? marketMakerRuntimeAgent.lastPlan
+                : null;
+        if (marketMakerPlan?.risk.staleStream) {
+            staleStreamGuardTripsSeen += 1;
+        }
+        if (marketMakerPlan?.risk.staleOracle) {
+            staleOracleGuardTripsSeen += 1;
+        }
+        if (marketMakerPlan?.risk.closingSoon) {
+            closeGuardTripsSeen += 1;
+        }
+        if (marketMakerPlan?.risk.circuitBreaker.active) {
+            circuitBreakerTripsSeen += 1;
+        }
+        if (marketMakerAgent) {
+            worstMarketMakerPnl = Math.min(
+                worstMarketMakerPnl,
+                marketMakerAgent.pnlValue,
+            );
+        }
+        peakInventorySeen = Math.max(
+            peakInventorySeen,
+            ...agentSnapshots.map((agent) => agent.inventoryUnits),
         );
 
-        // Build order book snapshot (scan populated price levels)
-        const book = await buildOrderBook();
-
-        const treasuryBalance = await provider.getBalance(treasuryAddr);
-        const mmBalance = await provider.getBalance(mmAddr);
+        const marketMakerDrawdownBps = marketMakerAgent
+            ? Math.round(
+                (Math.abs(Math.min(0, worstMarketMakerPnl)) /
+                    Math.max(
+                        0.0001,
+                        Number(initialBalances.get(marketMakerAgent.address) || "1"),
+                    )) *
+                    10_000,
+            )
+            : 0;
+        const claimsProcessed =
+            marketStatus < MARKET_STATUS_RESOLVED ||
+            agentSnapshots.every(
+                (agent) =>
+                    BigInt(agent.positionRaw.aShares) === 0n &&
+                    BigInt(agent.positionRaw.bShares) === 0n &&
+                    BigInt(agent.positionRaw.aStake) === 0n &&
+                    BigInt(agent.positionRaw.bStake) === 0n,
+            );
+        const settlementConsistent =
+            marketStatus === MARKET_STATUS_RESOLVED
+                ? Number(market.winner) === SIDE_A || Number(market.winner) === SIDE_B
+                : marketStatus === MARKET_STATUS_CANCELLED
+                  ? Number(market.winner) === 0
+                  : true;
+        const bookNotCrossed = boundedBestAsk == null || bestBid <= 0 || bestBid < boundedBestAsk;
+        const mmSolvent =
+            (marketMakerAgent ? Number(marketMakerAgent.balance) > 0 : true) &&
+            mmBalance > 0n;
+        const mitigationGates: MitigationGate[] = [
+            {
+                name: "mmSolvent",
+                passed: mmSolvent,
+                reason: mmSolvent ? null : "market-maker wallet depleted",
+            },
+            {
+                name: "bookNotCrossed",
+                passed: bookNotCrossed,
+                reason: bookNotCrossed ? null : "best bid crosses best ask",
+            },
+            {
+                name: "noPositiveAttackerPnl",
+                passed: bestAttackerPnlSeen <= 0,
+                reason:
+                    bestAttackerPnlSeen <= 0
+                        ? null
+                        : `attacker pnl peaked at ${bestAttackerPnlSeen.toFixed(4)} ETH`,
+            },
+            {
+                name: "settlementConsistent",
+                passed: settlementConsistent,
+                reason: settlementConsistent ? null : "winner/status mismatch after settlement",
+            },
+            {
+                name: "claimsProcessed",
+                passed: claimsProcessed,
+                reason: claimsProcessed ? null : "settled market still has residual positions",
+            },
+        ];
+        const activeScenarioPreset = getScenarioPresetByIdOrName(currentScenarioId);
+        const scenarioPolicyGates = activeScenarioPreset
+            ? evaluateScenarioPolicyGates(activeScenarioPreset, {
+                  attackerPnl: bestAttackerPnlSeen,
+                  maxDrawdownBps: marketMakerDrawdownBps,
+                  quoteUptimeRatio:
+                      scenarioObservedTicks > 0
+                          ? scenarioQuotedTicks / scenarioObservedTicks
+                          : 0,
+                  orderChurn,
+                  degraded: false,
+                  mmSolvent,
+                  bookNotCrossed,
+                  settlementConsistent,
+                  claimsProcessed,
+                  settlementStatus,
+                  staleStreamGuardTrips: staleStreamGuardTripsSeen,
+                  staleOracleGuardTrips: staleOracleGuardTripsSeen,
+                  closeGuardTrips: closeGuardTripsSeen,
+              })
+            : [];
+        const protocolMmPnl = Number(
+            formatEth(
+                mmBalance - ethers.parseEther(initialBalances.get(mmAddr) || "10000"),
+            ),
+        );
+        if (marketStatus === 1) {
+            scenarioObservedTicks += 1;
+            if ((marketMakerAgent?.activeOrders ?? 0) > 0) {
+                scenarioQuotedTicks += 1;
+            }
+            scenarioSpreadBpsTotal += spreadWidthBps;
+            scenarioSpreadSamples += 1;
+        }
 
         const state = {
             type: "state",
@@ -410,6 +1249,9 @@ async function broadcastState(): Promise<void> {
                 tick: simTick,
                 running: simRunning,
                 speed: simSpeed,
+                scenario: {
+                    id: currentScenarioId,
+                },
                 duel: {
                     label: currentDuelLabel,
                     key: currentDuelKey,
@@ -417,31 +1259,55 @@ async function broadcastState(): Promise<void> {
                 },
                 market: {
                     exists: market.exists,
-                    status: Number(market.status),
+                    status: marketStatus,
                     winner: Number(market.winner),
-                    bestBid: Number(market.bestBid),
-                    bestAsk: Number(market.bestAsk),
+                    bestBid,
+                    bestAsk,
                     totalAShares: market.totalAShares.toString(),
                     totalBShares: market.totalBShares.toString(),
                 },
                 contracts: {
-                    oracle: await oracle.getAddress(),
-                    clob: await clob.getAddress(),
+                    oracle: oracleAddr,
+                    clob: clobAddr,
                 },
                 fees: {
-                    treasuryBps: (await clob.tradeTreasuryFeeBps()).toString(),
-                    mmBps: (await clob.tradeMarketMakerFeeBps()).toString(),
-                    winningsMmBps: (await clob.winningsMarketMakerFeeBps()).toString(),
+                    treasuryBps: feeConfig.treasuryBps.toString(),
+                    mmBps: feeConfig.mmBps.toString(),
+                    winningsMmBps: feeConfig.winningsMmBps.toString(),
                     treasuryAccruedWei: (treasuryBalance - ethers.parseEther(initialBalances.get(treasuryAddr) || "10000")).toString(),
                     mmAccruedWei: (mmBalance - ethers.parseEther(initialBalances.get(mmAddr) || "10000")).toString(),
                 },
+                activeRun: getActiveScenarioRun(),
                 agents: agentStates,
                 book,
+                mitigation: {
+                    gates: mitigationGates,
+                    scenarioGates: scenarioPolicyGates,
+                    metrics: {
+                        attackerPnlCurrent: attackerPnl,
+                        attackerPnlPeak: bestAttackerPnlSeen,
+                        marketMakerPnl:
+                            marketMakerAgent?.pnlValue ?? 0,
+                        protocolMarketMakerPnl: protocolMmPnl,
+                        marketMakerDrawdownBps,
+                        peakInventory: peakInventorySeen,
+                        spreadWidthBps,
+                        orderChurn,
+                        staleStreamGuardTrips: staleStreamGuardTripsSeen,
+                        staleOracleGuardTrips: staleOracleGuardTripsSeen,
+                        closeGuardTrips: closeGuardTripsSeen,
+                        circuitBreakerTrips: circuitBreakerTripsSeen,
+                        settlementConsistent,
+                        claimsProcessed,
+                        settlementStatus,
+                    },
+                },
                 scenarios: SCENARIO_PRESETS,
                 eventLogCount: eventLog.length,
             },
         };
 
+        lastComputedState = state.data;
         broadcast(state);
     } catch (err: any) {
         console.error("[state] Error building state:", err.message);
@@ -453,32 +1319,77 @@ async function buildOrderBook(): Promise<{ bids: any[]; asks: any[] }> {
     const asks: { price: number; total: string }[] = [];
 
     // Sample price levels around the interesting range
-    const market = await clob.getMarket(currentDuelKey, MARKET_KIND_DUEL_WINNER);
+    const market = await withReadRetry(
+        "order-book getMarket",
+        () => clobRead.getMarket(currentDuelKey, MARKET_KIND_DUEL_WINNER),
+    );
     const bestBid = Number(market.bestBid);
     const bestAsk = Number(market.bestAsk);
 
     // Scan bid side downward from bestBid
     if (bestBid > 0) {
+        const prices: number[] = [];
         for (let p = bestBid; p >= Math.max(1, bestBid - 100); p -= 5) {
-            try {
-                const level = await clob.getPriceLevel(currentDuelKey, MARKET_KIND_DUEL_WINNER, BUY_SIDE, p);
-                if (level[2] > 0n) {
-                    bids.push({ price: p, total: level[2].toString() });
-                }
-            } catch { /* skip */ }
+            prices.push(p);
         }
+        const levels = await Promise.all(
+            prices.map(async (price) => {
+                try {
+                    const level = await withReadRetry(
+                        `order-book bid level ${price}`,
+                        () => clobRead.getPriceLevel(
+                            currentDuelKey,
+                            MARKET_KIND_DUEL_WINNER,
+                            BUY_SIDE,
+                            price,
+                        ),
+                    );
+                    return level[2] > 0n
+                        ? { price, total: level[2].toString() }
+                        : null;
+                } catch {
+                    return null;
+                }
+            }),
+        );
+        bids.push(
+            ...levels.filter(
+                (level): level is { price: number; total: string } => level != null,
+            ),
+        );
     }
 
     // Scan ask side upward from bestAsk
     if (bestAsk > 0 && bestAsk < MAX_PRICE) {
+        const prices: number[] = [];
         for (let p = bestAsk; p <= Math.min(999, bestAsk + 100); p += 5) {
-            try {
-                const level = await clob.getPriceLevel(currentDuelKey, MARKET_KIND_DUEL_WINNER, SELL_SIDE, p);
-                if (level[2] > 0n) {
-                    asks.push({ price: p, total: level[2].toString() });
-                }
-            } catch { /* skip */ }
+            prices.push(p);
         }
+        const levels = await Promise.all(
+            prices.map(async (price) => {
+                try {
+                    const level = await withReadRetry(
+                        `order-book ask level ${price}`,
+                        () => clobRead.getPriceLevel(
+                            currentDuelKey,
+                            MARKET_KIND_DUEL_WINNER,
+                            SELL_SIDE,
+                            price,
+                        ),
+                    );
+                    return level[2] > 0n
+                        ? { price, total: level[2].toString() }
+                        : null;
+                } catch {
+                    return null;
+                }
+            }),
+        );
+        asks.push(
+            ...levels.filter(
+                (level): level is { price: number; total: string } => level != null,
+            ),
+        );
     }
 
     return { bids, asks };
@@ -491,12 +1402,342 @@ async function runSimLoop(): Promise<void> {
     }
 }
 
+function buildScenarioTraces(limit = 80): AgentActionTrace[] {
+    return eventLog.slice(-limit).map((entry) => ({
+        actor: String(entry.args?.maker ?? "protocol"),
+        action: String(entry.event ?? "unknown"),
+        chainKey: "bsc",
+        duelKey: currentDuelKey,
+        marketRef: currentMarketKey,
+        price:
+            entry.args?.price == null
+                ? null
+                : Number(entry.args.price),
+        units:
+            entry.args?.amount != null
+                ? Number(entry.args.amount)
+                : entry.args?.matchedAmount != null
+                  ? Number(entry.args.matchedAmount)
+                  : null,
+        txRef: entry.txHash ?? null,
+        ok: true,
+        message: entry.event,
+    }));
+}
+
+function buildScenarioResult(
+    preset: ScenarioPreset,
+    seed: string,
+    options: {
+        degradedReasons?: Array<{
+            name: string;
+            reason: string;
+        }>;
+    } = {},
+): ScenarioResult {
+    const fallbackGates = [...(options.degradedReasons ?? [])].reverse().map(
+        (degradedReason) =>
+            ({
+                name: degradedReason.name,
+                passed: false,
+                reason: degradedReason.reason,
+            }) satisfies MitigationGate,
+    );
+    if (!lastComputedState) {
+        fallbackGates.unshift({
+            name: "stateCaptured",
+            passed: false,
+            reason: "Scenario finished without a computed state snapshot",
+        });
+        const marketMakerPnl = worstMarketMakerPnl;
+        const gates = fallbackGates;
+        return {
+            scenarioId: preset.id,
+            name: preset.name,
+            family: preset.family,
+            seed,
+            chainKey: "bsc",
+            attackerPnl: bestAttackerPnlSeen,
+            marketMakerPnl,
+            maxDrawdownBps: Math.round(
+                (Math.abs(Math.min(0, marketMakerPnl)) / 1) * 10_000,
+            ),
+            peakInventory: peakInventorySeen,
+            quoteUptimeRatio:
+                scenarioObservedTicks > 0
+                    ? scenarioQuotedTicks / scenarioObservedTicks
+                    : 0,
+            spreadWidthBps:
+                scenarioSpreadSamples > 0
+                    ? Math.round(scenarioSpreadBpsTotal / scenarioSpreadSamples)
+                    : 0,
+            orderChurn: eventLog.filter((entry) =>
+                entry.event === "OrderPlaced" ||
+                entry.event === "OrderCancelled" ||
+                entry.event === "OrderMatched",
+            ).length,
+            lockTransitionLatencyMs: lastResolveLatencyMs,
+            resolvedCorrectly: false,
+            claimCorrectly: false,
+            passed: gates.every((gate) => gate.passed),
+            degraded: true,
+            gates,
+            traces: buildScenarioTraces(),
+        };
+    }
+
+    const gates = [
+        ...(lastComputedState.mitigation.gates as MitigationGate[]),
+        ...((lastComputedState.mitigation.scenarioGates as MitigationGate[] | undefined) ?? []),
+    ];
+    gates.unshift(...fallbackGates);
+
+    const marketMakerSnapshotPnl = Number(
+        lastComputedState.mitigation.metrics.marketMakerPnl ?? 0,
+    );
+    const marketMakerPnl =
+        marketMakerSnapshotPnl !== 0 ? marketMakerSnapshotPnl : worstMarketMakerPnl;
+    const maxDrawdownBps = Math.round(
+        (Math.abs(Math.min(0, marketMakerPnl)) / 1) * 10_000,
+    );
+    const degraded = (options.degradedReasons?.length ?? 0) > 0;
+    const expectedSettledStatus =
+        preset.runtimeProfile?.settlementMode === "cancel"
+            ? MARKET_STATUS_CANCELLED
+            : MARKET_STATUS_RESOLVED;
+
+    return {
+        scenarioId: preset.id,
+        name: preset.name,
+        family: preset.family,
+        seed,
+        chainKey: "bsc",
+        attackerPnl: bestAttackerPnlSeen,
+        marketMakerPnl,
+        maxDrawdownBps,
+        peakInventory: peakInventorySeen,
+        quoteUptimeRatio:
+            scenarioObservedTicks > 0 ? scenarioQuotedTicks / scenarioObservedTicks : 0,
+        spreadWidthBps:
+            scenarioSpreadSamples > 0
+                ? Math.round(scenarioSpreadBpsTotal / scenarioSpreadSamples)
+                : Number(lastComputedState.mitigation.metrics.spreadWidthBps ?? 0),
+        orderChurn: eventLog.filter((entry) =>
+            entry.event === "OrderPlaced" ||
+            entry.event === "OrderCancelled" ||
+            entry.event === "OrderMatched",
+        ).length,
+        lockTransitionLatencyMs: lastResolveLatencyMs,
+        resolvedCorrectly: degraded
+            ? false
+            : Boolean(lastComputedState.mitigation.metrics.settlementConsistent) &&
+              Number(lastComputedState.market.status) === expectedSettledStatus,
+        claimCorrectly: degraded
+            ? false
+            : Boolean(lastComputedState.mitigation.metrics.claimsProcessed),
+        passed: gates.every((gate) => gate.passed),
+        degraded,
+        gates,
+        traces: buildScenarioTraces(),
+    };
+}
+
+async function runScenarioPreset(
+    run: ScenarioRunRecord,
+): Promise<ScenarioResult> {
+    if (scenarioRunInFlight) {
+        throw new Error("A scenario run is already in progress");
+    }
+
+    const preset = SCENARIO_PRESETS.find((entry) => entry.id === run.scenarioId);
+    if (!preset) {
+        throw new Error(`Unknown scenario preset: ${run.scenarioId}`);
+    }
+
+    scenarioRunInFlight = true;
+    activeScenarioRunId = run.runId;
+    try {
+        updateScenarioRun(run.runId, (entry) => {
+            entry.status = "running";
+            entry.stage = "restore-baseline";
+            entry.startedAt = Date.now();
+            entry.finishedAt = null;
+            entry.error = null;
+            entry.result = null;
+        });
+        if (run.freshBaseline) {
+            updateActiveRunStage("restore-baseline-rebuild");
+            await withTimeout(
+                rebuildSimulationEnvironment(),
+                SCENARIO_BASELINE_REBUILD_TIMEOUT_MS,
+                `scenario ${preset.id} fresh baseline rebuild`,
+            );
+        } else {
+            await restoreScenarioBaseline();
+        }
+        applyScenarioPresetByName(run.scenarioId);
+        const seed = run.seed;
+        const ticks = run.ticks;
+        const winner = run.winner;
+        const settlementMode =
+            preset.runtimeProfile?.settlementMode ?? "resolve";
+
+        setRandomSeed(seed);
+        broadcast({
+            type: "log",
+            data: {
+                message: `🧪 Scenario run starting: ${preset.name} seed=${seed} ticks=${ticks}`,
+                tick: simTick,
+            },
+        });
+
+        const degradedReasons: Array<{ name: string; reason: string }> = [];
+        const tickTimeoutMs = Math.max(20_000, countEnabledAgents() * 4_000);
+        for (let i = 0; i < ticks; i += 1) {
+            updateScenarioRun(run.runId, (entry) => {
+                entry.stage = `tick-${i + 1}-of-${ticks}`;
+            });
+            try {
+                await withTimeout(
+                    simulationTick(),
+                    tickTimeoutMs,
+                    `scenario ${preset.id} tick ${i + 1}`,
+                );
+            } catch (error) {
+                const reason =
+                    error instanceof Error ? error.message : String(error);
+                degradedReasons.push({
+                    name: "tickCompleted",
+                    reason,
+                });
+                broadcast({
+                    type: "log",
+                    data: {
+                        message: `⚠️ Scenario tick degraded: ${reason.slice(0, 140)}`,
+                        tick: simTick,
+                    },
+                });
+                break;
+            }
+        }
+
+        if (degradedReasons.length === 0) {
+            updateScenarioRun(run.runId, (entry) => {
+                entry.stage = "resolve";
+            });
+            try {
+                const resolveStartedAt = Date.now();
+                await withTimeout(
+                    settleDuel(settlementMode, winner === "B" ? SIDE_B : SIDE_A),
+                    SCENARIO_RESOLVE_TIMEOUT_MS,
+                    `scenario ${preset.id} settle`,
+                );
+                lastResolveLatencyMs = Date.now() - resolveStartedAt;
+            } catch (error) {
+                const reason =
+                    error instanceof Error ? error.message : String(error);
+                degradedReasons.push({
+                    name: "resolveCompleted",
+                    reason,
+                });
+                broadcast({
+                    type: "log",
+                    data: {
+                        message: `⚠️ Scenario resolve degraded: ${reason.slice(0, 140)}`,
+                        tick: simTick,
+                    },
+                });
+            }
+        }
+
+        if (degradedReasons.length > 0) {
+            try {
+                await withTimeout(
+                    broadcastState(),
+                    45_000,
+                    `scenario ${preset.id} final degraded broadcastState`,
+                );
+            } catch (refreshError) {
+                broadcast({
+                    type: "log",
+                    data: {
+                        message: `⚠️ Final degraded state refresh failed: ${
+                            refreshError instanceof Error
+                                ? refreshError.message.slice(0, 140)
+                                : String(refreshError).slice(0, 140)
+                        }`,
+                        tick: simTick,
+                    },
+                });
+            }
+        }
+
+        const result = buildScenarioResult(preset, seed, {
+            degradedReasons,
+        });
+        scenarioHistory = [result, ...scenarioHistory].slice(0, SCENARIO_HISTORY_LIMIT);
+        updateScenarioRun(run.runId, (entry) => {
+            entry.status = "succeeded";
+            entry.stage = degradedReasons.length > 0 ? "completed-degraded" : "completed";
+            entry.finishedAt = Date.now();
+            entry.error = degradedReasons.length > 0
+                ? degradedReasons.map((reason) => `${reason.name}: ${reason.reason}`).join("; ")
+                : null;
+            entry.result = result;
+        });
+        broadcast({
+            type: "scenario_result",
+            data: result,
+        });
+        return result;
+    } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        const activeStage = getActiveScenarioRun()?.stage ?? "scenario";
+        const degradedGateName = activeStage === "restore-baseline"
+            ? "baselineRestored"
+            : activeStage.startsWith("resolve")
+              ? "resolveCompleted"
+              : activeStage.startsWith("tick-")
+                ? "tickCompleted"
+                : "scenarioCompleted";
+        const result = buildScenarioResult(preset, run.seed, {
+            degradedReasons: [
+                {
+                    name: degradedGateName,
+                    reason,
+                },
+            ],
+        });
+        updateScenarioRun(run.runId, (entry) => {
+            entry.status = "succeeded";
+            entry.stage = "completed-degraded";
+            entry.finishedAt = Date.now();
+            entry.error = `${degradedGateName}: ${reason}`;
+            entry.result = result;
+        });
+        broadcast({
+            type: "scenario_result",
+            data: result,
+        });
+        return result;
+    } finally {
+        resetRandomSource();
+        scenarioRunInFlight = false;
+        activeScenarioRunId = null;
+        persistScenarioState();
+    }
+}
+
 // ─── Resolve Duel ────────────────────────────────────────────────────────────
 
-async function resolveDuel(winnerSide: number): Promise<void> {
+async function settleDuel(
+    settlementMode: ScenarioSettlementMode,
+    winnerSide: number,
+): Promise<void> {
   try {
     const reporter = await provider.getSigner(2);
     const operator = await provider.getSigner(1);
+    updateActiveRunStage("resolve-advance-time");
 
     // Advance Anvil's block time past the betting window (1 week forward)
     await provider.send("evm_increaseTime", [604800]);
@@ -505,24 +1746,63 @@ async function resolveDuel(winnerSide: number): Promise<void> {
     const block = await provider.getBlock("latest");
     const now = BigInt(block?.timestamp ?? Math.floor(Date.now() / 1000));
 
-    const tx1 = await (oracle.connect(reporter) as any).reportResult(
-      currentDuelKey,
-      winnerSide,
-      BigInt(Math.floor(Math.random() * 1000000)),
-      ethers.keccak256(ethers.toUtf8Bytes(`replay-${currentDuelLabel}`)),
-      ethers.keccak256(ethers.toUtf8Bytes(`result-${currentDuelLabel}`)),
-      now,
-      `resolved-${currentDuelLabel}`,
-    );
-    await tx1.wait();
+    let tx1: any;
+    if (settlementMode === "cancel") {
+        updateActiveRunStage("resolve-cancel-duel");
+        tx1 = await withTimeout(
+            (oracle.connect(reporter) as any).cancelDuel(
+                currentDuelKey,
+                `cancelled-${currentDuelLabel}`,
+            ),
+            SCENARIO_SETTLEMENT_TX_TIMEOUT_MS,
+            "resolve cancelDuel",
+        );
+        await withTimeout(
+            tx1.wait(),
+            SCENARIO_SETTLEMENT_RECEIPT_TIMEOUT_MS,
+            "resolve cancelDuel receipt",
+        );
+    } else {
+        updateActiveRunStage("resolve-report-result");
+        tx1 = await withTimeout(
+            (oracle.connect(reporter) as any).reportResult(
+                currentDuelKey,
+                winnerSide,
+                BigInt(Math.floor(random() * 1000000)),
+                ethers.keccak256(ethers.toUtf8Bytes(`replay-${currentDuelLabel}`)),
+                ethers.keccak256(ethers.toUtf8Bytes(`result-${currentDuelLabel}`)),
+                now,
+                `resolved-${currentDuelLabel}`,
+            ),
+            SCENARIO_SETTLEMENT_TX_TIMEOUT_MS,
+            "resolve reportResult",
+        );
+        await withTimeout(
+            tx1.wait(),
+            SCENARIO_SETTLEMENT_RECEIPT_TIMEOUT_MS,
+            "resolve reportResult receipt",
+        );
+    }
 
-    const tx2 = await (clob.connect(operator) as any).syncMarketFromOracle(currentDuelKey, MARKET_KIND_DUEL_WINNER);
-    await tx2.wait();
+    updateActiveRunStage("resolve-sync-market");
+    const tx2: any = await withTimeout(
+        (clob.connect(operator) as any).syncMarketFromOracle(currentDuelKey, MARKET_KIND_DUEL_WINNER),
+        SCENARIO_SETTLEMENT_TX_TIMEOUT_MS,
+        "resolve syncMarketFromOracle",
+    );
+    await withTimeout(
+        tx2.wait(),
+        SCENARIO_SETTLEMENT_RECEIPT_TIMEOUT_MS,
+        "resolve syncMarketFromOracle receipt",
+    );
 
     broadcast({
         type: "log",
         data: {
-            message: `🏆 Duel resolved! Winner: Side ${winnerSide === SIDE_A ? "A" : "B"}`,
+            message:
+                settlementMode === "cancel"
+                    ? "🧾 Duel cancelled and refunds unlocked"
+                    : `🏆 Duel resolved! Winner: Side ${winnerSide === SIDE_A ? "A" : "B"}`,
             tick: simTick,
         },
     });
@@ -531,33 +1811,58 @@ async function resolveDuel(winnerSide: number): Promise<void> {
     simRunning = false;
     broadcast({ type: "log", data: { message: "⏸️ Simulation auto-paused after resolution. Click 'New Duel' then 'Start' to continue.", tick: simTick } });
 
-    // Auto-claim for all agents
-    for (const agent of agents) {
-        try {
-            const position = await clob.positions(currentMarketKey, await agent.signer.getAddress());
-            if (position.aShares > 0n || position.bShares > 0n) {
-                const txClaim = await (clob.connect(agent.signer) as any).claim(currentDuelKey, MARKET_KIND_DUEL_WINNER);
-                await txClaim.wait();
-                broadcast({
-                    type: "log",
-                    data: { message: `[${agent.config.name}] Claimed winnings`, tick: simTick },
-                });
-            }
-        } catch (err: any) {
-            broadcast({
-                type: "log",
-                data: { message: `[${agent.config.name}] Claim: ${err.message?.slice(0, 80)}`, tick: simTick },
+    updateActiveRunStage("resolve-scan-claims");
+    refreshReadClients();
+    const claimCandidates: ClaimCandidate[] = [];
+    for (const [index, agent] of agents.entries()) {
+        updateActiveRunStage(`resolve-position-${index + 1}-of-${agents.length}`);
+        const address = await getAgentAddress(agent);
+        const position = await loadClaimPosition(agent, address);
+        if (position && hasPosition(position)) {
+            claimCandidates.push({
+                agent,
+                address,
+                position,
             });
         }
     }
 
-    await broadcastState();
+    await processClaimCandidates(
+        claimCandidates,
+        "resolve-claims",
+        RESOLVE_CLAIM_BUDGET_MS,
+    );
+
+    updateActiveRunStage("resolve-final-state");
+    await withTimeout(
+        broadcastState(),
+        60_000,
+        "resolve final broadcastState",
+    );
+
+    if (!lastComputedState?.mitigation.metrics.claimsProcessed) {
+        const residualCandidates = getResidualClaimCandidates();
+        if (residualCandidates.length > 0) {
+            await processClaimCandidates(
+                residualCandidates,
+                "resolve-residual-claims",
+                Math.max(10_000, Math.floor(RESOLVE_CLAIM_BUDGET_MS / 2)),
+            );
+            updateActiveRunStage("resolve-final-state-residual");
+            await withTimeout(
+                broadcastState(),
+                60_000,
+                "resolve residual broadcastState",
+            );
+        }
+    }
   } catch (err: any) {
     broadcast({
         type: "log",
         data: { message: `⚠️ Resolution error: ${err.message?.slice(0, 120)}`, tick: simTick },
     });
     console.error("[resolve] Error:", err.shortMessage || err.message);
+    throw err;
   }
 }
 
@@ -601,16 +1906,16 @@ function handleWsMessage(data: string): void {
                 break;
 
             case "scenario": {
-                const preset = SCENARIO_PRESETS.find((p) => p.name === msg.value);
+                const preset = SCENARIO_PRESETS.find(
+                    (p) => p.name === msg.value || p.id === msg.value,
+                );
                 if (preset) {
-                    for (const agent of agents) {
-                        agent.config.enabled = preset.enabledStrategies.includes(agent.config.strategy);
-                    }
+                    applyScenarioPresetByName(preset.id);
                     broadcast({
                         type: "log",
                         data: { message: `🎯 Scenario: ${preset.name}`, tick: simTick },
                     });
-                    broadcastState();
+                    void broadcastState();
                 }
                 break;
             }
@@ -626,7 +1931,7 @@ function handleWsMessage(data: string): void {
 
             case "resolve": {
                 const side = msg.winner === "B" ? SIDE_B : SIDE_A;
-                resolveDuel(side);
+                settleDuel("resolve", side);
                 break;
             }
 
@@ -688,21 +1993,160 @@ function serveStatic(req: IncomingMessage, res: ServerResponse): void {
     }
 }
 
+function writeJson(
+    res: ServerResponse,
+    statusCode: number,
+    payload: unknown,
+): void {
+    res.writeHead(statusCode, {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+    });
+    res.end(JSON.stringify(payload, null, 2));
+}
+
+async function handleHttpRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+): Promise<void> {
+    const requestUrl = new URL(
+        req.url ?? "/",
+        `http://${req.headers.host ?? `127.0.0.1:${HTTP_PORT}`}`,
+    );
+
+    if (requestUrl.pathname === "/api/state") {
+        writeJson(res, 200, {
+            ok: true,
+            state: lastComputedState,
+        });
+        return;
+    }
+
+    if (requestUrl.pathname === "/api/scenarios") {
+        writeJson(res, 200, {
+            ok: true,
+            scenarios: SCENARIO_PRESETS,
+            gateScenarios: GATE_SCENARIOS,
+            latest: scenarioHistory[0] ?? null,
+            activeRun: getActiveScenarioRun(),
+            runs: scenarioRuns.slice(0, SCENARIO_HISTORY_LIMIT),
+            historyCount: scenarioHistory.length,
+        });
+        return;
+    }
+
+    if (requestUrl.pathname === "/api/scenarios/results") {
+        const runId = requestUrl.searchParams.get("runId");
+        if (runId) {
+            const run = scenarioRuns.find((entry) => entry.runId === runId) ?? null;
+            writeJson(res, run ? 200 : 404, {
+                ok: run != null,
+                run,
+                error: run ? null : `Unknown runId: ${runId}`,
+            });
+            return;
+        }
+        writeJson(res, 200, {
+            ok: true,
+            activeRun: getActiveScenarioRun(),
+            runs: scenarioRuns.slice(0, SCENARIO_HISTORY_LIMIT),
+            results: scenarioHistory,
+        });
+        return;
+    }
+
+    if (requestUrl.pathname === "/api/scenarios/run") {
+        if (scenarioRunInFlight) {
+            writeJson(res, 409, {
+                ok: false,
+                error: "A scenario run is already in progress",
+                run: getActiveScenarioRun(),
+            });
+            return;
+        }
+        const scenarioName =
+            requestUrl.searchParams.get("name") ??
+            requestUrl.searchParams.get("id");
+        if (!scenarioName) {
+            writeJson(res, 400, {
+                ok: false,
+                error: "Missing scenario name or id",
+            });
+            return;
+        }
+
+        try {
+            const preset = SCENARIO_PRESETS.find(
+                (entry) => entry.name === scenarioName || entry.id === scenarioName,
+            );
+            if (!preset) {
+                writeJson(res, 404, {
+                    ok: false,
+                    error: `Unknown scenario: ${scenarioName}`,
+                });
+                return;
+            }
+            const ticksParam = requestUrl.searchParams.get("ticks");
+            const winnerParam = requestUrl.searchParams.get("winner");
+            const run = createScenarioRunRecord(preset, {
+                seed: requestUrl.searchParams.get("seed") ?? undefined,
+                ticks:
+                    ticksParam == null || ticksParam === ""
+                        ? undefined
+                        : Number(ticksParam),
+                winner:
+                    winnerParam === "A" || winnerParam === "B"
+                        ? winnerParam
+                        : undefined,
+                freshBaseline:
+                    requestUrl.searchParams.get("fresh") === "1" ||
+                    requestUrl.searchParams.get("fresh") === "true",
+            });
+            scenarioRuns = [run, ...scenarioRuns].slice(0, SCENARIO_HISTORY_LIMIT);
+            persistScenarioState();
+            void runScenarioPreset(run).catch((error) => {
+                console.error(
+                    `[scenario] ${run.runId} failed: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            });
+            writeJson(res, 202, {
+                ok: true,
+                run,
+            });
+        } catch (error) {
+            writeJson(res, 500, {
+                ok: false,
+                error: (error as Error).message,
+            });
+        }
+        return;
+    }
+
+    serveStatic(req, res);
+}
+
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
     console.log("╔══════════════════════════════════════════════════════════╗");
     console.log("║   Hyperbet Simulation Dashboard                        ║");
     console.log("╚══════════════════════════════════════════════════════════╝");
+    loadScenarioState();
 
     // 1. Start Anvil
     await startAnvil();
 
     // 2. Deploy contracts
     await deployContracts();
+    await captureScenarioBaseline();
+    await broadcastState();
 
     // 3. Start HTTP server
-    const httpServer = createServer(serveStatic);
+    const httpServer = createServer((req, res) => {
+        void handleHttpRequest(req, res);
+    });
     httpServer.listen(HTTP_PORT, () => {
         console.log(`[http] Dashboard at http://localhost:${HTTP_PORT}`);
     });
@@ -728,10 +2172,11 @@ async function main(): Promise<void> {
     // Cleanup on exit
     const cleanup = () => {
         simRunning = false;
-        stopAnvil();
         wss.close();
         httpServer.close();
-        process.exit(0);
+        void stopAnvil().finally(() => {
+            process.exit(0);
+        });
     };
 
     process.on("SIGINT", cleanup);
@@ -742,6 +2187,7 @@ async function main(): Promise<void> {
 
 main().catch((err) => {
     console.error("Fatal:", err);
-    stopAnvil();
-    process.exit(1);
+    void stopAnvil().finally(() => {
+        process.exit(1);
+    });
 });

--- a/packages/simulation-dashboard/tsconfig.json
+++ b/packages/simulation-dashboard/tsconfig.json
@@ -14,5 +14,8 @@
     },
     "include": [
         "src/**/*.ts"
+    ],
+    "exclude": [
+        "src/**/*.test.ts"
     ]
 }


### PR DESCRIPTION
## Summary
- add the EVM proof layer on top of the shared multichain foundation
- harden GoldClob settlement behavior and add dedicated settlement/fuzz coverage
- promote the adversarial simulation runtime, scenario catalog, and evaluation layer needed for EVM exploit testing

## Included
- GoldClob settlement cleanup behavior and regression tests
- Foundry settlement test suite and fuzz suite for EVM prediction-market contracts
- simulation-dashboard scenario catalog, evaluator, and CLI
- EVM adversarial simulation runtime/server updates used by the exploit gate

## Intentionally Excluded
- CI workflow promotion and gate wiring
- Solana proof backend and runtime artifact contract
- deploy/staging rails
- local Gate 10 harnesses
- release/docs-only work

## Why This Is Safe To Merge Next
- it builds directly on the shared foundation from PR 1
- it contains the contract/runtime proof machinery without changing deploy topology
- later CI and deploy PRs can wire these lanes without re-reviewing contract semantics

## Checks Run
- `bun test packages/simulation-dashboard/src/scenario-evaluator.test.ts`
- `bunx tsc --noEmit -p packages/simulation-dashboard/tsconfig.json`
- `forge test --match-path packages/evm-contracts/test/GoldClobSettlement.t.sol`

## Reviewer Focus
- contract settlement semantics
- exploit scenario/policy model
- simulation runtime correctness without CI/deploy policy noise
