### PR TITLE
fix: split shared rpc reads from submit paths

### DIFF
--- a/packages/hyperbet-avax/keeper/src/service.ts
+++ b/packages/hyperbet-avax/keeper/src/service.ts
@@ -27,7 +27,11 @@ import {
   type VerifiedExternalBetRecord,
 } from "@hyperbet/evm-keeper-core";
 import {
+  findUnsupportedJsonRpcMethod,
+  isWriteRateLimitedRoute,
   mergePredictionMarketsWithHealth,
+  PUBLIC_EVM_RPC_READ_METHODS,
+  PUBLIC_SOLANA_RPC_READ_METHODS,
   type KeeperBotHealthSnapshot,
   type KeeperMarketHealthRecord,
 } from "@hyperbet/mm-core";
@@ -2832,6 +2836,19 @@ async function handleSolanaRpcProxy(req: Request): Promise<Response> {
   if (!rpcBody.ok) {
     return rpcBody.response;
   }
+  const unsupportedMethod = findUnsupportedJsonRpcMethod(
+    rpcBody.requests,
+    PUBLIC_SOLANA_RPC_READ_METHODS,
+  );
+  if (unsupportedMethod) {
+    return jsonResponse(
+      req,
+      {
+        error: `JSON-RPC method ${unsupportedMethod} is not allowed on the public Solana RPC proxy`,
+      },
+      403,
+    );
+  }
 
   try {
     const ttlMs = resolveJsonRpcCacheTtlMs(
@@ -2960,6 +2977,19 @@ async function handleEvmRpcProxy(req: Request, url: URL): Promise<Response> {
   const rpcBody = await readJsonRpcBody(req, EVM_RPC_PROXY_MAX_BODY_BYTES);
   if (!rpcBody.ok) {
     return rpcBody.response;
+  }
+  const unsupportedMethod = findUnsupportedJsonRpcMethod(
+    rpcBody.requests,
+    PUBLIC_EVM_RPC_READ_METHODS,
+  );
+  if (unsupportedMethod) {
+    return jsonResponse(
+      req,
+      {
+        error: `JSON-RPC method ${unsupportedMethod} is not allowed on the public EVM RPC proxy`,
+      },
+      403,
+    );
   }
 
   try {
@@ -3116,8 +3146,7 @@ const server = Bun.serve({
   development: process.env.NODE_ENV !== "production",
   fetch: async (req: Request) => {
     const url = new URL(req.url);
-    const isWriteRoute =
-      req.method === "POST" || url.pathname === "/api/streaming/state/publish";
+    const isWriteRoute = isWriteRateLimitedRoute(req.method, url.pathname);
     const allowed = checkRateLimit(
       req,
       url.pathname,

--- a/packages/hyperbet-bsc/keeper/src/service.ts
+++ b/packages/hyperbet-bsc/keeper/src/service.ts
@@ -28,7 +28,11 @@ import {
   type VerifiedExternalBetRecord,
 } from "@hyperbet/evm-keeper-core";
 import {
+  findUnsupportedJsonRpcMethod,
+  isWriteRateLimitedRoute,
   mergePredictionMarketsWithHealth,
+  PUBLIC_EVM_RPC_READ_METHODS,
+  PUBLIC_SOLANA_RPC_READ_METHODS,
   type KeeperBotHealthSnapshot,
   type KeeperMarketHealthRecord,
 } from "@hyperbet/mm-core";
@@ -2775,6 +2779,19 @@ async function handleSolanaRpcProxy(req: Request): Promise<Response> {
   if (!rpcBody.ok) {
     return rpcBody.response;
   }
+  const unsupportedMethod = findUnsupportedJsonRpcMethod(
+    rpcBody.requests,
+    PUBLIC_SOLANA_RPC_READ_METHODS,
+  );
+  if (unsupportedMethod) {
+    return jsonResponse(
+      req,
+      {
+        error: `JSON-RPC method ${unsupportedMethod} is not allowed on the public Solana RPC proxy`,
+      },
+      403,
+    );
+  }
 
   try {
     const ttlMs = resolveJsonRpcCacheTtlMs(
@@ -2903,6 +2920,19 @@ async function handleEvmRpcProxy(req: Request, url: URL): Promise<Response> {
   const rpcBody = await readJsonRpcBody(req, EVM_RPC_PROXY_MAX_BODY_BYTES);
   if (!rpcBody.ok) {
     return rpcBody.response;
+  }
+  const unsupportedMethod = findUnsupportedJsonRpcMethod(
+    rpcBody.requests,
+    PUBLIC_EVM_RPC_READ_METHODS,
+  );
+  if (unsupportedMethod) {
+    return jsonResponse(
+      req,
+      {
+        error: `JSON-RPC method ${unsupportedMethod} is not allowed on the public EVM RPC proxy`,
+      },
+      403,
+    );
   }
 
   try {
@@ -3059,8 +3089,7 @@ const server = Bun.serve({
   development: process.env.NODE_ENV !== "production",
   fetch: async (req: Request) => {
     const url = new URL(req.url);
-    const isWriteRoute =
-      req.method === "POST" || url.pathname === "/api/streaming/state/publish";
+    const isWriteRoute = isWriteRateLimitedRoute(req.method, url.pathname);
     const allowed = checkRateLimit(
       req,
       url.pathname,

--- a/packages/hyperbet-evm/keeper/src/service.ts
+++ b/packages/hyperbet-evm/keeper/src/service.ts
@@ -25,7 +25,11 @@ import {
   type VerifiedExternalBetRecord,
 } from "@hyperbet/evm-keeper-core";
 import {
+  findUnsupportedJsonRpcMethod,
+  isWriteRateLimitedRoute,
   mergePredictionMarketsWithHealth,
+  PUBLIC_EVM_RPC_READ_METHODS,
+  PUBLIC_SOLANA_RPC_READ_METHODS,
   type KeeperBotHealthSnapshot,
   type KeeperMarketHealthRecord,
 } from "@hyperbet/mm-core";
@@ -3438,6 +3442,19 @@ async function handleSolanaRpcProxy(req: Request): Promise<Response> {
   if (!rpcBody.ok) {
     return rpcBody.response;
   }
+  const unsupportedMethod = findUnsupportedJsonRpcMethod(
+    rpcBody.requests,
+    PUBLIC_SOLANA_RPC_READ_METHODS,
+  );
+  if (unsupportedMethod) {
+    return jsonResponse(
+      req,
+      {
+        error: `JSON-RPC method ${unsupportedMethod} is not allowed on the public Solana RPC proxy`,
+      },
+      403,
+    );
+  }
 
   try {
     const ttlMs = resolveJsonRpcCacheTtlMs(
@@ -3566,6 +3583,19 @@ async function handleEvmRpcProxy(req: Request, url: URL): Promise<Response> {
   const rpcBody = await readJsonRpcBody(req, EVM_RPC_PROXY_MAX_BODY_BYTES);
   if (!rpcBody.ok) {
     return rpcBody.response;
+  }
+  const unsupportedMethod = findUnsupportedJsonRpcMethod(
+    rpcBody.requests,
+    PUBLIC_EVM_RPC_READ_METHODS,
+  );
+  if (unsupportedMethod) {
+    return jsonResponse(
+      req,
+      {
+        error: `JSON-RPC method ${unsupportedMethod} is not allowed on the public EVM RPC proxy`,
+      },
+      403,
+    );
   }
 
   try {
@@ -3729,8 +3759,7 @@ const server = Bun.serve({
   development: process.env.NODE_ENV !== "production",
   fetch: async (req: Request) => {
     const url = new URL(req.url);
-    const isWriteRoute =
-      req.method === "POST" || url.pathname === "/api/streaming/state/publish";
+    const isWriteRoute = isWriteRateLimitedRoute(req.method, url.pathname);
     const allowed = checkRateLimit(
       req,
       url.pathname,

--- a/packages/hyperbet-mm-core/src/index.ts
+++ b/packages/hyperbet-mm-core/src/index.ts
@@ -840,3 +840,5 @@ export function buildAmmTradeDecision(
     reason: `deviation-${deviationBps}bps`,
   };
 }
+
+export * from "./rpcProxyPolicy.js";

--- a/packages/hyperbet-mm-core/src/rpcProxyPolicy.test.ts
+++ b/packages/hyperbet-mm-core/src/rpcProxyPolicy.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  findUnsupportedJsonRpcMethod,
+  isWriteRateLimitedRoute,
+  PUBLIC_EVM_RPC_READ_METHODS,
+  PUBLIC_SOLANA_RPC_READ_METHODS,
+} from "./rpcProxyPolicy.js";
+
+describe("rpc proxy policy", () => {
+  test("treats public RPC proxy POSTs as read traffic", () => {
+    expect(isWriteRateLimitedRoute("POST", "/api/proxy/solana/rpc")).toBe(
+      false,
+    );
+    expect(isWriteRateLimitedRoute("POST", "/api/proxy/evm/rpc")).toBe(false);
+    expect(isWriteRateLimitedRoute("GET", "/api/perps/markets")).toBe(false);
+  });
+
+  test("keeps write and unknown POST routes on the write bucket", () => {
+    expect(
+      isWriteRateLimitedRoute("POST", "/api/streaming/state/publish"),
+    ).toBe(true);
+    expect(
+      isWriteRateLimitedRoute("POST", "/api/arena/invite/redeem"),
+    ).toBe(true);
+    expect(
+      isWriteRateLimitedRoute("POST", "/api/proxy/solana/sender"),
+    ).toBe(true);
+    expect(isWriteRateLimitedRoute("POST", "/api/unknown")).toBe(true);
+  });
+
+  test("allows the public EVM read subset and rejects send methods", () => {
+    expect(
+      findUnsupportedJsonRpcMethod(
+        [
+          { method: "eth_chainId" },
+          { method: "eth_getTransactionCount" },
+          { method: "eth_estimateGas" },
+          { method: "eth_gasPrice" },
+        ],
+        PUBLIC_EVM_RPC_READ_METHODS,
+      ),
+    ).toBeNull();
+
+    expect(
+      findUnsupportedJsonRpcMethod(
+        [{ method: "eth_sendRawTransaction" }],
+        PUBLIC_EVM_RPC_READ_METHODS,
+      ),
+    ).toBe("eth_sendRawTransaction");
+  });
+
+  test("allows Solana read/confirm methods and rejects sendTransaction", () => {
+    expect(
+      findUnsupportedJsonRpcMethod(
+        [
+          { method: "getLatestBlockhash" },
+          { method: "getSignatureStatuses" },
+          { method: "getTokenAccountsByOwner" },
+        ],
+        PUBLIC_SOLANA_RPC_READ_METHODS,
+      ),
+    ).toBeNull();
+
+    expect(
+      findUnsupportedJsonRpcMethod(
+        [{ method: "sendTransaction" }],
+        PUBLIC_SOLANA_RPC_READ_METHODS,
+      ),
+    ).toBe("sendTransaction");
+  });
+});

--- a/packages/hyperbet-mm-core/src/rpcProxyPolicy.ts
+++ b/packages/hyperbet-mm-core/src/rpcProxyPolicy.ts
@@ -1,0 +1,106 @@
+export type JsonRpcMethodRequest = {
+  method: string;
+};
+
+type AllowedJsonRpcMethods =
+  | Readonly<Record<string, unknown>>
+  | ReadonlySet<string>
+  | readonly string[];
+
+const READ_RATE_LIMIT_POST_PATHS = new Set([
+  "/api/proxy/solana/rpc",
+  "/api/proxy/evm/rpc",
+]);
+
+const WRITE_RATE_LIMIT_POST_PATHS = new Set([
+  "/api/streaming/state/publish",
+  "/api/arena/bet/record-external",
+  "/api/arena/invite/redeem",
+  "/api/arena/wallet-link",
+  "/api/proxy/solana/sender",
+]);
+
+export const PUBLIC_EVM_RPC_READ_METHODS = new Set([
+  "eth_blockNumber",
+  "eth_call",
+  "eth_chainId",
+  "eth_estimateGas",
+  "eth_gasPrice",
+  "eth_getBalance",
+  "eth_getBlockByNumber",
+  "eth_getCode",
+  "eth_getLogs",
+  "eth_getStorageAt",
+  "eth_getTransactionByHash",
+  "eth_getTransactionCount",
+  "eth_getTransactionReceipt",
+  "net_version",
+  "web3_clientVersion",
+]);
+
+export const PUBLIC_SOLANA_RPC_READ_METHODS = new Set([
+  "getAccountInfo",
+  "getBalance",
+  "getBlockHeight",
+  "getBlockTime",
+  "getEpochInfo",
+  "getEpochSchedule",
+  "getFeeForMessage",
+  "getGenesisHash",
+  "getHealth",
+  "getIdentity",
+  "getLatestBlockhash",
+  "getMinimumBalanceForRentExemption",
+  "getMultipleAccounts",
+  "getProgramAccounts",
+  "getRecentPrioritizationFees",
+  "getSignatureStatuses",
+  "getSlot",
+  "getSupply",
+  "getTokenAccountBalance",
+  "getTokenAccountsByOwner",
+  "getTokenLargestAccounts",
+  "getTokenSupply",
+  "getVersion",
+]);
+
+function isAllowedJsonRpcMethod(
+  method: string,
+  allowedMethods: AllowedJsonRpcMethods,
+): boolean {
+  if (allowedMethods instanceof Set) {
+    return allowedMethods.has(method);
+  }
+  if (Array.isArray(allowedMethods)) {
+    return allowedMethods.includes(method);
+  }
+  return Object.hasOwn(allowedMethods, method);
+}
+
+export function findUnsupportedJsonRpcMethod(
+  requests: readonly JsonRpcMethodRequest[],
+  allowedMethods: AllowedJsonRpcMethods,
+): string | null {
+  for (const request of requests) {
+    if (!isAllowedJsonRpcMethod(request.method, allowedMethods)) {
+      return request.method;
+    }
+  }
+  return null;
+}
+
+export function isWriteRateLimitedRoute(
+  method: string,
+  pathname: string,
+): boolean {
+  if (method.toUpperCase() !== "POST") {
+    return false;
+  }
+  if (READ_RATE_LIMIT_POST_PATHS.has(pathname)) {
+    return false;
+  }
+  if (WRITE_RATE_LIMIT_POST_PATHS.has(pathname)) {
+    return true;
+  }
+  return true;
+}

--- a/packages/hyperbet-solana/keeper/src/service.ts
+++ b/packages/hyperbet-solana/keeper/src/service.ts
@@ -16,7 +16,10 @@ import {
   type RecordedBetChain,
 } from "@hyperbet/chain-registry";
 import {
+  findUnsupportedJsonRpcMethod,
+  isWriteRateLimitedRoute,
   mergePredictionMarketsWithHealth,
+  PUBLIC_SOLANA_RPC_READ_METHODS,
   type KeeperBotHealthSnapshot,
   type KeeperMarketHealthRecord,
 } from "@hyperbet/mm-core";
@@ -133,6 +136,10 @@ type ParserState = {
 type RateBucket = {
   tokens: number;
   lastRefillMs: number;
+};
+
+type JsonRpcRequestPayload = Record<string, unknown> & {
+  method: string;
 };
 
 const encoder = new TextEncoder();
@@ -2592,6 +2599,19 @@ async function handleSolanaRpcProxy(req: Request): Promise<Response> {
   if (!rpcBody.ok) {
     return rpcBody.response;
   }
+  const unsupportedMethod = findUnsupportedJsonRpcMethod(
+    rpcBody.requests,
+    PUBLIC_SOLANA_RPC_READ_METHODS,
+  );
+  if (unsupportedMethod) {
+    return jsonResponse(
+      req,
+      {
+        error: `JSON-RPC method ${unsupportedMethod} is not allowed on the public Solana RPC proxy`,
+      },
+      403,
+    );
+  }
 
   try {
     const upstream = await fetch(SOLANA_RPC_PROXY_URL, {
@@ -2730,7 +2750,7 @@ async function handleSolanaSenderProxy(req: Request): Promise<Response> {
 }
 
 type JsonRpcBodyResult =
-  | { ok: true; bodyText: string }
+  | { ok: true; bodyText: string; requests: JsonRpcRequestPayload[] }
   | { ok: false; response: Response };
 
 async function readJsonRpcBody(
@@ -2775,7 +2795,9 @@ async function readJsonRpcBody(
     };
   }
 
-  const requests = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
+  const requests = (
+    Array.isArray(parsedBody) ? parsedBody : [parsedBody]
+  ) as JsonRpcRequestPayload[];
   const hasInvalidRequest = requests.some((entry) => {
     if (!entry || typeof entry !== "object") return true;
     const method = (entry as Record<string, unknown>).method;
@@ -2788,7 +2810,14 @@ async function readJsonRpcBody(
     };
   }
 
-  return { ok: true, bodyText };
+  return {
+    ok: true,
+    bodyText,
+    requests: requests.map((entry) => ({
+      ...entry,
+      method: entry.method.trim(),
+    })),
+  };
 }
 
 async function handleBirdeyePrice(req: Request, url: URL): Promise<Response> {
@@ -2904,8 +2933,7 @@ const server = Bun.serve({
   development: process.env.NODE_ENV !== "production",
   fetch: async (req: Request) => {
     const url = new URL(req.url);
-    const isWriteRoute =
-      req.method === "POST" || url.pathname === "/api/streaming/state/publish";
+    const isWriteRoute = isWriteRateLimitedRoute(req.method, url.pathname);
     const allowed = checkRateLimit(
       req,
       url.pathname,

--- a/packages/hyperbet-ui/src/lib/chainConfig.ts
+++ b/packages/hyperbet-ui/src/lib/chainConfig.ts
@@ -5,7 +5,7 @@ import {
 } from "@hyperbet/chain-registry";
 import type { Chain } from "wagmi/chains";
 
-import { CONFIG, getEvmRpcUrl } from "./config";
+import { CONFIG, getEvmReadRpcUrl, getEvmSubmitRpcUrl } from "./config";
 
 export type ChainId = "solana" | BettingEvmChain;
 
@@ -15,6 +15,8 @@ export type EvmChainConfig = {
   name: string;
   shortName: string;
   rpcUrl: string;
+  readRpcUrl: string;
+  submitRpcUrl: string;
   goldClobAddress: string;
   nativeCurrency: { name: string; symbol: string; decimals: number };
   blockExplorer: string;
@@ -87,24 +89,28 @@ function getRuntimeChainConfig(chainKey: BettingEvmChain): EvmChainConfig | null
   const blockExplorer =
     runtime.chainId === runtime.deployment.chainId
       ? runtime.deployment.blockExplorerUrl
-      : getEvmRpcUrl(chainKey);
+      : getEvmReadRpcUrl(chainKey);
   const isTestnet =
     runtime.deployment.targetKind === "testnet" ||
     runtime.chainId !== runtime.deployment.chainId;
+  const readRpcUrl = getEvmReadRpcUrl(chainKey);
+  const submitRpcUrl = getEvmSubmitRpcUrl(chainKey);
 
   return {
     chainId: chainKey,
     evmChainId: runtime.chainId,
     name,
     shortName,
-    rpcUrl: getEvmRpcUrl(chainKey),
+    rpcUrl: readRpcUrl,
+    readRpcUrl,
+    submitRpcUrl,
     goldClobAddress: runtime.goldClobAddress,
     nativeCurrency: runtime.deployment.nativeCurrency,
     blockExplorer,
     wagmiChain: createCustomChain({
       chainId: runtime.chainId,
       name,
-      rpcUrl: getEvmRpcUrl(chainKey),
+      rpcUrl: readRpcUrl,
       blockExplorer,
       nativeCurrency: runtime.deployment.nativeCurrency,
       testnet: isTestnet,

--- a/packages/hyperbet-ui/src/lib/config.ts
+++ b/packages/hyperbet-ui/src/lib/config.ts
@@ -702,27 +702,39 @@ function resolvedEvmNetworkKey(
   return chainId === 43114 ? "avax" : "avaxFuji";
 }
 
-export function getEvmRpcUrl(chain: BettingEvmChain): string {
-  if (shouldUseGameEvmRpcProxy()) {
-    return `${GAME_API_URL}/api/proxy/evm/rpc?chain=${encodeURIComponent(chain)}`;
-  }
+function getDirectEvmRpcUrl(chain: BettingEvmChain): string {
   return CONFIG.evmChains[chain]?.rpcUrl ?? defaultRpcUrlForEvmNetwork(
     resolveBettingEvmDefaults(asDeploymentEnvironment(RUNTIME_ENV))[chain]
       .networkKey,
   );
 }
 
-export const BSC_RPC_URL: string = getEvmRpcUrl("bsc");
+export function getEvmReadRpcUrl(chain: BettingEvmChain): string {
+  if (shouldUseGameEvmRpcProxy()) {
+    return `${GAME_API_URL}/api/proxy/evm/rpc?chain=${encodeURIComponent(chain)}`;
+  }
+  return getDirectEvmRpcUrl(chain);
+}
+
+export function getEvmSubmitRpcUrl(chain: BettingEvmChain): string {
+  return getDirectEvmRpcUrl(chain);
+}
+
+export function getEvmRpcUrl(chain: BettingEvmChain): string {
+  return getEvmReadRpcUrl(chain);
+}
+
+export const BSC_RPC_URL: string = getEvmReadRpcUrl("bsc");
 export const BSC_CHAIN_ID: number = CONFIG.bscChainId;
 export const BSC_GOLD_CLOB_ADDRESS: string = CONFIG.bscGoldClobAddress;
 export const BSC_GOLD_TOKEN_ADDRESS: string = CONFIG.bscGoldTokenAddress;
 
-export const BASE_RPC_URL: string = getEvmRpcUrl("base");
+export const BASE_RPC_URL: string = getEvmReadRpcUrl("base");
 export const BASE_CHAIN_ID: number = CONFIG.baseChainId;
 export const BASE_GOLD_CLOB_ADDRESS: string = CONFIG.baseGoldClobAddress;
 export const BASE_GOLD_TOKEN_ADDRESS: string = CONFIG.baseGoldTokenAddress;
 
-export const AVAX_RPC_URL: string = getEvmRpcUrl("avax");
+export const AVAX_RPC_URL: string = getEvmReadRpcUrl("avax");
 export const AVAX_CHAIN_ID: number = CONFIG.avaxChainId;
 export const AVAX_GOLD_CLOB_ADDRESS: string = CONFIG.avaxGoldClobAddress;
 export const AVAX_GOLD_TOKEN_ADDRESS: string = CONFIG.avaxGoldTokenAddress;

--- a/packages/hyperbet-ui/src/lib/evmClient.ts
+++ b/packages/hyperbet-ui/src/lib/evmClient.ts
@@ -161,7 +161,7 @@ export function createEvmPublicClient(
   return createPublicClient({
     chain: chainConfig.wagmiChain,
     ccipRead: false,
-    transport: createEvmTransport(chainConfig.rpcUrl),
+    transport: createEvmTransport(chainConfig.readRpcUrl),
   });
 }
 
@@ -202,7 +202,7 @@ export function createUnlockedRpcWalletClient(
         functionName,
         args: (args ?? []) as readonly unknown[],
       });
-      const response = await fetch(chainConfig.rpcUrl, {
+      const response = await fetch(chainConfig.submitRpcUrl, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
@@ -304,12 +304,14 @@ export function createSignedRpcWalletClient(
         ...(value !== undefined ? { value: toHex(value) } : {}),
       };
       const [nonceHex, gasPriceHex, gasEstimateHex] = await Promise.all([
-        callEvmRpc<Hex>(chainConfig.rpcUrl, "eth_getTransactionCount", [
+        callEvmRpc<Hex>(chainConfig.submitRpcUrl, "eth_getTransactionCount", [
           from,
           "pending",
         ]),
-        callEvmRpc<Hex>(chainConfig.rpcUrl, "eth_gasPrice", []),
-        callEvmRpc<Hex>(chainConfig.rpcUrl, "eth_estimateGas", [txRequest]),
+        callEvmRpc<Hex>(chainConfig.submitRpcUrl, "eth_gasPrice", []),
+        callEvmRpc<Hex>(chainConfig.submitRpcUrl, "eth_estimateGas", [
+          txRequest,
+        ]),
       ]);
       const serialized = await account.signTransaction({
         chainId: chainConfig.evmChainId,
@@ -321,9 +323,11 @@ export function createSignedRpcWalletClient(
         type: "legacy",
         value: value ?? 0n,
       });
-      return callEvmRpc<Hash>(chainConfig.rpcUrl, "eth_sendRawTransaction", [
-        serialized,
-      ]);
+      return callEvmRpc<Hash>(
+        chainConfig.submitRpcUrl,
+        "eth_sendRawTransaction",
+        [serialized],
+      );
     },
   };
 }

--- a/packages/hyperbet-ui/src/lib/jupiter.ts
+++ b/packages/hyperbet-ui/src/lib/jupiter.ts
@@ -2,6 +2,8 @@ import { CONFIG } from "./config";
 import { WalletContextState } from "@solana/wallet-adapter-react";
 import { Connection, VersionedTransaction } from "@solana/web3.js";
 
+import { confirmSignatureViaRpc, sendRawTransactionViaRpc } from "./solanaRpc";
+
 const DEFAULT_JUPITER_BASE_URL = CONFIG.jupiterBaseUrl;
 
 type QuoteResponse = {
@@ -70,12 +72,7 @@ export async function swapToGoldViaJupiter(params: {
   );
 
   const signed = await wallet.signTransaction(tx);
-  const signature = await connection.sendRawTransaction(signed.serialize(), {
-    maxRetries: 3,
-    skipPreflight: false,
-    preflightCommitment: "confirmed",
-  });
-
-  await connection.confirmTransaction(signature, "confirmed");
+  const signature = await sendRawTransactionViaRpc(connection, signed);
+  await confirmSignatureViaRpc(connection, signature);
   return signature;
 }

--- a/packages/hyperbet-ui/src/lib/solanaRpc.ts
+++ b/packages/hyperbet-ui/src/lib/solanaRpc.ts
@@ -86,6 +86,29 @@ function resolveRpcEndpoint(endpoint: string): string {
   return endpoint;
 }
 
+function isKeeperSolanaReadProxyEndpoint(endpoint: string): boolean {
+  try {
+    return new URL(resolveRpcEndpoint(endpoint)).pathname === "/api/proxy/solana/rpc";
+  } catch {
+    return false;
+  }
+}
+
+function resolveSolanaSenderEndpoint(endpoint: string): string {
+  const resolvedEndpoint = resolveRpcEndpoint(endpoint);
+  try {
+    const parsed = new URL(resolvedEndpoint);
+    if (parsed.pathname === "/api/proxy/solana/rpc") {
+      parsed.pathname = "/api/proxy/solana/sender";
+      parsed.search = "";
+      return parsed.toString();
+    }
+  } catch {
+    // Fall through to the resolved endpoint.
+  }
+  return resolvedEndpoint;
+}
+
 async function callJsonRpc<T>(
   endpoint: string,
   method: string,
@@ -121,6 +144,31 @@ async function callJsonRpc<T>(
   return payload.result;
 }
 
+async function sendTransactionViaProxySender(
+  endpoint: string,
+  wireTransactionBase64: string,
+): Promise<string> {
+  const response = await fetch(resolveSolanaSenderEndpoint(endpoint), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      transaction: wireTransactionBase64,
+    }),
+  });
+
+  const payload = (await response.json()) as
+    | { signature: string }
+    | { error?: string };
+  if (!response.ok || !("signature" in payload)) {
+    throw new Error(
+      ("error" in payload && payload.error) || `sendTransaction HTTP ${response.status}`,
+    );
+  }
+  return payload.signature;
+}
+
 export async function getLatestBlockhashViaRpc(
   connection: Connection,
 ): Promise<{
@@ -144,6 +192,13 @@ export async function sendRawTransactionViaRpc(
   transaction: Transaction | VersionedTransaction,
 ): Promise<string> {
   const serialized = transaction.serialize();
+  const wireTransactionBase64 = Buffer.from(serialized).toString("base64");
+  if (isKeeperSolanaReadProxyEndpoint(connection.rpcEndpoint)) {
+    return sendTransactionViaProxySender(
+      connection.rpcEndpoint,
+      wireTransactionBase64,
+    );
+  }
   try {
     return await connection.sendRawTransaction(serialized, {
       preflightCommitment: "confirmed",
@@ -152,7 +207,7 @@ export async function sendRawTransactionViaRpc(
     });
   } catch {
     return callJsonRpc<string>(connection.rpcEndpoint, "sendTransaction", [
-      Buffer.from(serialized).toString("base64"),
+      wireTransactionBase64,
       {
         encoding: "base64",
         preflightCommitment: "confirmed",

--- a/packages/hyperbet-ui/src/lib/token.ts
+++ b/packages/hyperbet-ui/src/lib/token.ts
@@ -5,6 +5,8 @@ import {
 } from "@solana/spl-token";
 import { Connection, PublicKey, Transaction } from "@solana/web3.js";
 
+import { confirmSignatureViaRpc, sendRawTransactionViaRpc } from "./solanaRpc";
+
 function isMintLookupError(error: unknown): boolean {
   const message = (error as Error)?.message?.toLowerCase?.() ?? "";
   return message.includes("could not find mint");
@@ -92,25 +94,14 @@ export async function confirmTx(
   connection: Connection,
   signature: string,
 ): Promise<void> {
-  const latest = await connection.getLatestBlockhash("confirmed");
-  await connection.confirmTransaction(
-    {
-      signature,
-      blockhash: latest.blockhash,
-      lastValidBlockHeight: latest.lastValidBlockHeight,
-    },
-    "confirmed",
-  );
+  await confirmSignatureViaRpc(connection, signature);
 }
 
 export async function sendTx(
   connection: Connection,
   signedTx: Transaction,
 ): Promise<string> {
-  const signature = await connection.sendRawTransaction(signedTx.serialize(), {
-    skipPreflight: false,
-    preflightCommitment: "confirmed",
-  });
+  const signature = await sendRawTransactionViaRpc(connection, signedTx);
   await confirmTx(connection, signature);
   return signature;
 }

--- a/packages/hyperbet-ui/src/lib/wagmiConfig.ts
+++ b/packages/hyperbet-ui/src/lib/wagmiConfig.ts
@@ -12,12 +12,12 @@ import { CONFIG } from "./config";
 const chains = getWagmiChains();
 const enabledEvmChains = getEnabledEvmChains();
 const fallbackRpcUrl =
-  enabledEvmChains[0]?.rpcUrl ?? chains[0]?.rpcUrls.default.http[0] ?? "";
+  enabledEvmChains[0]?.readRpcUrl ?? chains[0]?.rpcUrls.default.http[0] ?? "";
 
 // Build transport map from enabled chains
 const transports: Record<number, ReturnType<typeof http>> = {};
 for (const evmChain of enabledEvmChains) {
-  transports[evmChain.evmChainId] = http(evmChain.rpcUrl);
+  transports[evmChain.evmChainId] = http(evmChain.readRpcUrl);
 }
 // Fallback for any chain that didn't get explicitly mapped
 for (const chain of chains) {

--- a/packages/hyperbet-ui/tests/solanaRpc.test.ts
+++ b/packages/hyperbet-ui/tests/solanaRpc.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { sendRawTransactionViaRpc } from "../src/lib/solanaRpc";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("solanaRpc", () => {
+  test("routes keeper-backed submit traffic to the sender endpoint", async () => {
+    const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe(
+        "https://keeper.example.com/api/proxy/solana/sender",
+      );
+      expect(init?.method).toBe("POST");
+
+      const payload = JSON.parse(String(init?.body)) as {
+        transaction: string;
+      };
+      expect(payload.transaction).toBe("AQID");
+
+      return new Response(JSON.stringify({ signature: "sig-123" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const signature = await sendRawTransactionViaRpc(
+      {
+        rpcEndpoint:
+          "https://keeper.example.com/api/proxy/solana/rpc?cluster=mainnet-beta",
+      } as any,
+      {
+        serialize: () => Uint8Array.from([1, 2, 3]),
+      } as any,
+    );
+
+    expect(signature).toBe("sig-123");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- move shared public EVM and Solana RPC proxy POSTs onto the read rate-limit bucket
- keep the public RPC proxy read-only with explicit JSON-RPC allowlists
- split EVM read RPC from submit RPC so RPC-backed write paths bypass the public read proxy
- reroute Solana submit traffic to the dedicated sender endpoint while keeping confirmation on the read proxy

## Why
Production Base reads were going through `POST /api/proxy/evm/rpc` and being charged against the write bucket, which caused repeated `429 Too Many Requests` responses. Tightening the proxy without separating read and submit traffic would also have broken legitimate Solana submit flows and EVM RPC-backed write flows.

## Validation
- `bun test packages/hyperbet-mm-core/src/rpcProxyPolicy.test.ts`
- `bun test packages/hyperbet-ui/tests/solanaRpc.test.ts --preload ./packages/hyperbet-ui/tests/setup.ts`
- `bunx tsc --noEmit -p packages/hyperbet-mm-core/tsconfig.json`
- `bunx tsc --noEmit -p packages/hyperbet-ui/tsconfig.verify.json`
- `bunx tsc --noEmit -p packages/hyperbet-evm/keeper/tsconfig.json`
- local proxy smoke: Base `eth_chainId` -> `200`, Base `eth_sendRawTransaction` -> `403`, Solana `getLatestBlockhash` -> `200`, Solana `getSignatureStatuses` -> `200`, Solana `sendTransaction` on read proxy -> `403`, 75 consecutive Base reads stayed `200`

## Out of Scope
- workflow or deploy-contract normalization changes
- backlog, board, or documentation updates
- pre-existing keeper package script TypeScript errors outside this hotfix surface