### PR TITLE
fix: restore bsc models tab navigation

### DIFF
--- a/packages/hyperbet-bsc/app/src/App.tsx
+++ b/packages/hyperbet-bsc/app/src/App.tsx
@@ -1491,7 +1491,7 @@ export function App() {
                 <button
                   data-testid="surface-mode-duels"
                   className={`hm-view-tab ${surfaceMode === "DUELS" ? "hm-view-tab--active" : ""}`}
-                  onClick={() => startTransition(() => setSurfaceMode("DUELS"))}
+                  onClick={() => setSurfaceMode("DUELS")}
                   type="button"
                 >
                   {copy.duels}
@@ -1499,9 +1499,7 @@ export function App() {
                 <button
                   data-testid="surface-mode-models"
                   className={`hm-view-tab ${surfaceMode === "MODELS" ? "hm-view-tab--active" : ""}`}
-                  onClick={() =>
-                    startTransition(() => setSurfaceMode("MODELS"))
-                  }
+                  onClick={() => setSurfaceMode("MODELS")}
                   type="button"
                 >
                   {copy.models}
@@ -1529,7 +1527,7 @@ export function App() {
                 <button
                   data-testid="surface-mode-duels"
                   className={`hm-view-tab ${surfaceMode === "DUELS" ? "hm-view-tab--active" : ""}`}
-                  onClick={() => startTransition(() => setSurfaceMode("DUELS"))}
+                  onClick={() => setSurfaceMode("DUELS")}
                   type="button"
                 >
                   {copy.duels}
@@ -1537,9 +1535,7 @@ export function App() {
                 <button
                   data-testid="surface-mode-models"
                   className={`hm-view-tab ${surfaceMode === "MODELS" ? "hm-view-tab--active" : ""}`}
-                  onClick={() =>
-                    startTransition(() => setSurfaceMode("MODELS"))
-                  }
+                  onClick={() => setSurfaceMode("MODELS")}
                   type="button"
                 >
                   {copy.models}


### PR DESCRIPTION
## Summary
- remove `startTransition(...)` from the BSC surface-mode tab toggles
- restore reliable switching between Duels and Models in the BSC app header

## Verification
- reproduced the broken Models-tab behavior on the personal BSC staging Pages deploy
- verified the fix locally against the production build flow
- confirmed the repaired behavior on personal staging after redeploy
