### PR TITLE
fix: route CI builds through chain-specific keeper variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,10 @@ jobs:
             audit_target: pages:solana
             build_mode: mainnet-beta
             solana_cluster: mainnet-beta
+            keeper_url_var: HYPERBET_SOLANA_KEEPER_URL
+            keeper_ws_url_var: HYPERBET_SOLANA_KEEPER_WS_URL
+            keeper_fallback_url: "https://api.hyperbet.win"
+            keeper_fallback_ws_url: "wss://api.hyperbet.win/ws"
             avax_chain_id: ""
             avax_gold_clob_address: ""
           - package: hyperbet-bsc
@@ -233,6 +237,10 @@ jobs:
             audit_target: pages:bsc
             build_mode: mainnet-beta
             solana_cluster: mainnet-beta
+            keeper_url_var: HYPERBET_BSC_KEEPER_URL
+            keeper_ws_url_var: HYPERBET_BSC_KEEPER_WS_URL
+            keeper_fallback_url: "https://bsc-api.hyperbet.win"
+            keeper_fallback_ws_url: "wss://bsc-api.hyperbet.win/ws"
             avax_chain_id: ""
             avax_gold_clob_address: ""
           - package: hyperbet-avax
@@ -240,12 +248,16 @@ jobs:
             audit_target: app:avax
             build_mode: testnet
             solana_cluster: testnet
+            keeper_url_var: HYPERBET_AVAX_KEEPER_URL
+            keeper_ws_url_var: HYPERBET_AVAX_KEEPER_WS_URL
+            keeper_fallback_url: "https://avax-api.hyperbet.win"
+            keeper_fallback_ws_url: "wss://avax-api.hyperbet.win/ws"
             avax_chain_id: ""
             avax_gold_clob_address: ""
     env:
       CF_PAGES_COMMIT_SHA: ${{ github.sha }}
-      VITE_GAME_API_URL: https://api.hyperbet.win
-      VITE_GAME_WS_URL: wss://api.hyperbet.win/ws
+      VITE_GAME_API_URL: ${{ vars[matrix.keeper_url_var] || matrix.keeper_fallback_url }}
+      VITE_GAME_WS_URL: ${{ vars[matrix.keeper_ws_url_var] || matrix.keeper_fallback_ws_url }}
       VITE_SOLANA_CLUSTER: ${{ matrix.solana_cluster }}
       VITE_USE_GAME_RPC_PROXY: "true"
       VITE_USE_GAME_EVM_RPC_PROXY: "true"
@@ -335,8 +347,8 @@ jobs:
     needs: shared-validation
     env:
       CF_PAGES_COMMIT_SHA: ${{ github.sha }}
-      VITE_GAME_API_URL: https://api.hyperbet.win
-      VITE_GAME_WS_URL: wss://api.hyperbet.win/ws
+      VITE_GAME_API_URL: ${{ vars.HYPERBET_BSC_KEEPER_URL || 'https://bsc-api.hyperbet.win' }}
+      VITE_GAME_WS_URL: ${{ vars.HYPERBET_BSC_KEEPER_WS_URL || 'wss://bsc-api.hyperbet.win/ws' }}
       VITE_SOLANA_CLUSTER: mainnet-beta
       VITE_USE_GAME_RPC_PROXY: "true"
       VITE_USE_GAME_EVM_RPC_PROXY: "true"

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@hyperbet/monorepo",
@@ -306,7 +305,6 @@
         "@solana/web3.js": "^1.95.4",
         "bn.js": "^5.2.1",
         "bs58": "^6.0.0",
-        "clsx": "^2.1.1",
         "ethers": "^6.13.4",
       },
       "devDependencies": {

--- a/packages/hyperbet-bsc/app/src/lib/config.ts
+++ b/packages/hyperbet-bsc/app/src/lib/config.ts
@@ -276,7 +276,7 @@ interface EnvConfig {
 const DEFAULT_STREAM_URL = "https://www.twitch.tv/hyperscapeai";
 const DEFAULT_STREAM_FALLBACK_URL = "";
 const DEFAULT_GAME_API_URL = "http://127.0.0.1:5555";
-const DEFAULT_PRODUCTION_GAME_API_URL = "https://gold-betting-keeper-production.up.railway.app";
+const DEFAULT_PRODUCTION_GAME_API_URL = "https://bsc-api.hyperbet.win";
 
 const baseConfig: Partial<EnvConfig> = {
   betWindowSeconds: 300,

--- a/packages/hyperbet-solana/app/src/lib/config.ts
+++ b/packages/hyperbet-solana/app/src/lib/config.ts
@@ -182,7 +182,7 @@ export interface EnvConfig {
 const DEFAULT_STREAM_URL = "https://www.twitch.tv/hyperscapeai";
 const DEFAULT_STREAM_FALLBACK_URL = "";
 const DEFAULT_GAME_API_URL = "http://127.0.0.1:5555";
-const DEFAULT_PRODUCTION_GAME_API_URL = "https://gold-betting-keeper-production.up.railway.app";
+const DEFAULT_PRODUCTION_GAME_API_URL = "https://api.hyperbet.win";
 
 const baseConfig: Partial<EnvConfig> = {
   betWindowSeconds: 300,

--- a/packages/hyperbet-ui/src/lib/config.ts
+++ b/packages/hyperbet-ui/src/lib/config.ts
@@ -289,7 +289,7 @@ export interface EnvConfig {
 const DEFAULT_STREAM_URL = "https://www.twitch.tv/hyperscapeai";
 const DEFAULT_STREAM_FALLBACK_URL = "";
 const DEFAULT_GAME_API_URL = "http://127.0.0.1:5555";
-const DEFAULT_PRODUCTION_GAME_API_URL = "https://gold-betting-keeper-production.up.railway.app";
+const DEFAULT_PRODUCTION_GAME_API_URL = "https://api.hyperbet.win";
 const DEFAULT_LOCAL_STREAM_URL =
   "http://127.0.0.1:3333/stream.html?disableBridgeCapture=1";
 


### PR DESCRIPTION
## Summary
- Add per-chain keeper URL variables to the CI matrix so each package build resolves `VITE_GAME_API_URL` from its own GitHub variable with public-facing domains preserved as last-resort fallbacks
  - Solana: `vars.HYPERBET_SOLANA_KEEPER_URL` || `https://api.hyperbet.win`
  - BSC: `vars.HYPERBET_BSC_KEEPER_URL` || `https://bsc-api.hyperbet.win`
  - AVAX: `vars.HYPERBET_AVAX_KEEPER_URL` || `https://avax-api.hyperbet.win`
- EVM validation job uses `vars.HYPERBET_BSC_KEEPER_URL` || `https://bsc-api.hyperbet.win`
- Restore public-facing domains in client config.ts defaults (Solana, BSC, shared UI) replacing previously hardcoded Railway infrastructure URLs
- Deploy workflows unchanged — already have the correct variable-first, public-domain-fallback pattern

## Test plan
- [ ] CI matrix resolves correct keeper URL per chain from GitHub variables
- [ ] Builds fall back to public domains if variables are unset
- [ ] No Railway infrastructure URLs in committed code