### PR TITLE
fix: port staging stream hardening and market sizing into develop

### DIFF
--- a/packages/hyperbet-bsc/app/src/App.tsx
+++ b/packages/hyperbet-bsc/app/src/App.tsx
@@ -1737,70 +1737,72 @@ export function App() {
                 </div>
 
                 {/* Odds Chart */}
-                <div className="hm-chart-panel">
-                  <div className="hm-chart-toolbar">
-                    <button className="hm-chart-tool-btn" type="button">
-                      +
-                    </button>
-                    <button className="hm-chart-tool-btn" type="button">
-                      &#9881;
-                    </button>
-                    <button className="hm-chart-tool-btn" type="button">
-                      &#9634;
-                    </button>
+                {!isMobile && (
+                  <div className="hm-chart-panel">
+                    <div className="hm-chart-toolbar">
+                      <button className="hm-chart-tool-btn" type="button">
+                        +
+                      </button>
+                      <button className="hm-chart-tool-btn" type="button">
+                        &#9881;
+                      </button>
+                      <button className="hm-chart-tool-btn" type="button">
+                        &#9634;
+                      </button>
+                    </div>
+                    <div className="hm-chart-price-label">
+                      <span className="hm-chart-price-current">
+                        {(effYesPercent / 100).toFixed(1)}
+                      </span>
+                    </div>
+                    <div className="hm-chart-container">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <LineChart data={effChartData}>
+                          <XAxis
+                            dataKey="time"
+                            tick={{ fill: "rgba(255,255,255,0.3)", fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
+                            tickFormatter={(v: number) => {
+                              const d = new Date(v);
+                              return `${d.getHours()}:${String(d.getMinutes()).padStart(2, "0")}`;
+                            }}
+                          />
+                          <YAxis
+                            domain={[0, 100]}
+                            tick={{ fill: "rgba(255,255,255,0.3)", fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
+                            width={40}
+                            tickFormatter={(v: number) => `${v}%`}
+                          />
+                          <Tooltip
+                            content={({ active, payload }) =>
+                              active && payload?.length ? (
+                                <div className="hm-chart-tooltip">
+                                  <span>{payload[0].value}%</span>
+                                </div>
+                              ) : null
+                            }
+                          />
+                          <ReferenceLine
+                            y={50}
+                            stroke="rgba(255,255,255,0.06)"
+                            strokeDasharray="4 4"
+                          />
+                          <Line
+                            type="monotone"
+                            dataKey="pct"
+                            stroke="#e5b84a"
+                            strokeWidth={2}
+                            dot={false}
+                            isAnimationActive
+                          />
+                        </LineChart>
+                      </ResponsiveContainer>
+                    </div>
                   </div>
-                  <div className="hm-chart-price-label">
-                    <span className="hm-chart-price-current">
-                      {(effYesPercent / 100).toFixed(1)}
-                    </span>
-                  </div>
-                  <div className="hm-chart-container">
-                    <ResponsiveContainer width="100%" height="100%">
-                      <LineChart data={effChartData}>
-                        <XAxis
-                          dataKey="time"
-                          tick={{ fill: "rgba(255,255,255,0.3)", fontSize: 11 }}
-                          tickLine={false}
-                          axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
-                          tickFormatter={(v: number) => {
-                            const d = new Date(v);
-                            return `${d.getHours()}:${String(d.getMinutes()).padStart(2, "0")}`;
-                          }}
-                        />
-                        <YAxis
-                          domain={[0, 100]}
-                          tick={{ fill: "rgba(255,255,255,0.3)", fontSize: 11 }}
-                          tickLine={false}
-                          axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
-                          width={40}
-                          tickFormatter={(v: number) => `${v}%`}
-                        />
-                        <Tooltip
-                          content={({ active, payload }) =>
-                            active && payload?.length ? (
-                              <div className="hm-chart-tooltip">
-                                <span>{payload[0].value}%</span>
-                              </div>
-                            ) : null
-                          }
-                        />
-                        <ReferenceLine
-                          y={50}
-                          stroke="rgba(255,255,255,0.06)"
-                          strokeDasharray="4 4"
-                        />
-                        <Line
-                          type="monotone"
-                          dataKey="pct"
-                          stroke="#e5b84a"
-                          strokeWidth={2}
-                          dot={false}
-                          isAnimationActive
-                        />
-                      </LineChart>
-                    </ResponsiveContainer>
-                  </div>
-                </div>
+                )}
               </div>
 
               <ResizeHandle

--- a/packages/hyperbet-bsc/app/src/App.tsx
+++ b/packages/hyperbet-bsc/app/src/App.tsx
@@ -36,6 +36,7 @@ import { PointsDisplay } from "@hyperbet/ui/components/PointsDisplay";
 import { useChain } from "./lib/ChainContext";
 import { useStreamingState } from "@hyperbet/ui/spectator/useStreamingState";
 import { useDuelContext } from "@hyperbet/ui/spectator/useDuelContext";
+import { useMeasuredContentBox } from "@hyperbet/ui/lib/useMeasuredContentBox";
 import { useResizePanel, useIsMobile } from "@hyperbet/ui/lib/useResizePanel";
 import { ResizeHandle } from "@hyperbet/ui/components/ResizeHandle";
 import {
@@ -44,7 +45,6 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
   ReferenceLine,
 } from "recharts";
 
@@ -721,37 +721,10 @@ export function App() {
   const appRootRef = useRef<HTMLDivElement | null>(null);
   const bettingDockInnerRef = useRef<HTMLDivElement | null>(null);
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
-  const [chartReady, setChartReady] = useState(false);
+  const chartSize = useMeasuredContentBox(chartContainerRef, !isMobile, 2);
 
   const { state: streamingState } = useStreamingState();
   const { context: duelContext } = useDuelContext();
-
-  useEffect(() => {
-    const container = chartContainerRef.current;
-    if (!container) return;
-
-    const updateChartReady = () => {
-      const nextReady =
-        container.clientWidth > 0 && container.clientHeight > 0;
-      setChartReady((prevReady) =>
-        prevReady === nextReady ? prevReady : nextReady,
-      );
-    };
-
-    updateChartReady();
-
-    const resizeObserver =
-      typeof ResizeObserver !== "undefined"
-        ? new ResizeObserver(updateChartReady)
-        : null;
-    resizeObserver?.observe(container);
-
-    window.addEventListener("resize", updateChartReady);
-    return () => {
-      resizeObserver?.disconnect();
-      window.removeEventListener("resize", updateChartReady);
-    };
-  }, []);
   const liveCycle = streamingState?.cycle ?? null;
   const lifecycleChainKey =
     activeChain === "bsc" || activeChain === "base" || activeChain === "avax"
@@ -1785,57 +1758,59 @@ export function App() {
                       </span>
                     </div>
                     <div className="hm-chart-container" ref={chartContainerRef}>
-                      {chartReady ? (
-                        <ResponsiveContainer width="100%" height="100%">
-                          <LineChart data={effChartData}>
-                            <XAxis
-                              dataKey="time"
-                              tick={{
-                                fill: "rgba(255,255,255,0.3)",
-                                fontSize: 11,
-                              }}
-                              tickLine={false}
-                              axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
-                              tickFormatter={(v: number) => {
-                                const d = new Date(v);
-                                return `${d.getHours()}:${String(d.getMinutes()).padStart(2, "0")}`;
-                              }}
-                            />
-                            <YAxis
-                              domain={[0, 100]}
-                              tick={{
-                                fill: "rgba(255,255,255,0.3)",
-                                fontSize: 11,
-                              }}
-                              tickLine={false}
-                              axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
-                              width={40}
-                              tickFormatter={(v: number) => `${v}%`}
-                            />
-                            <Tooltip
-                              content={({ active, payload }) =>
-                                active && payload?.length ? (
-                                  <div className="hm-chart-tooltip">
-                                    <span>{payload[0].value}%</span>
-                                  </div>
-                                ) : null
-                              }
-                            />
-                            <ReferenceLine
-                              y={50}
-                              stroke="rgba(255,255,255,0.06)"
-                              strokeDasharray="4 4"
-                            />
-                            <Line
-                              type="monotone"
-                              dataKey="pct"
-                              stroke="#e5b84a"
-                              strokeWidth={2}
-                              dot={false}
-                              isAnimationActive
-                            />
-                          </LineChart>
-                        </ResponsiveContainer>
+                      {chartSize ? (
+                        <LineChart
+                          data={effChartData}
+                          width={chartSize.width}
+                          height={chartSize.height}
+                        >
+                          <XAxis
+                            dataKey="time"
+                            tick={{
+                              fill: "rgba(255,255,255,0.3)",
+                              fontSize: 11,
+                            }}
+                            tickLine={false}
+                            axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
+                            tickFormatter={(v: number) => {
+                              const d = new Date(v);
+                              return `${d.getHours()}:${String(d.getMinutes()).padStart(2, "0")}`;
+                            }}
+                          />
+                          <YAxis
+                            domain={[0, 100]}
+                            tick={{
+                              fill: "rgba(255,255,255,0.3)",
+                              fontSize: 11,
+                            }}
+                            tickLine={false}
+                            axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
+                            width={40}
+                            tickFormatter={(v: number) => `${v}%`}
+                          />
+                          <Tooltip
+                            content={({ active, payload }) =>
+                              active && payload?.length ? (
+                                <div className="hm-chart-tooltip">
+                                  <span>{payload[0].value}%</span>
+                                </div>
+                              ) : null
+                            }
+                          />
+                          <ReferenceLine
+                            y={50}
+                            stroke="rgba(255,255,255,0.06)"
+                            strokeDasharray="4 4"
+                          />
+                          <Line
+                            type="monotone"
+                            dataKey="pct"
+                            stroke="#e5b84a"
+                            strokeWidth={2}
+                            dot={false}
+                            isAnimationActive
+                          />
+                        </LineChart>
                       ) : null}
                     </div>
                   </div>

--- a/packages/hyperbet-bsc/app/src/App.tsx
+++ b/packages/hyperbet-bsc/app/src/App.tsx
@@ -720,9 +720,38 @@ export function App() {
   >("leaderboard");
   const appRootRef = useRef<HTMLDivElement | null>(null);
   const bettingDockInnerRef = useRef<HTMLDivElement | null>(null);
+  const chartContainerRef = useRef<HTMLDivElement | null>(null);
+  const [chartReady, setChartReady] = useState(false);
 
   const { state: streamingState } = useStreamingState();
   const { context: duelContext } = useDuelContext();
+
+  useEffect(() => {
+    const container = chartContainerRef.current;
+    if (!container) return;
+
+    const updateChartReady = () => {
+      const nextReady =
+        container.clientWidth > 0 && container.clientHeight > 0;
+      setChartReady((prevReady) =>
+        prevReady === nextReady ? prevReady : nextReady,
+      );
+    };
+
+    updateChartReady();
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(updateChartReady)
+        : null;
+    resizeObserver?.observe(container);
+
+    window.addEventListener("resize", updateChartReady);
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", updateChartReady);
+    };
+  }, []);
   const liveCycle = streamingState?.cycle ?? null;
   const lifecycleChainKey =
     activeChain === "bsc" || activeChain === "base" || activeChain === "avax"
@@ -1755,51 +1784,59 @@ export function App() {
                         {(effYesPercent / 100).toFixed(1)}
                       </span>
                     </div>
-                    <div className="hm-chart-container">
-                      <ResponsiveContainer width="100%" height="100%">
-                        <LineChart data={effChartData}>
-                          <XAxis
-                            dataKey="time"
-                            tick={{ fill: "rgba(255,255,255,0.3)", fontSize: 11 }}
-                            tickLine={false}
-                            axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
-                            tickFormatter={(v: number) => {
-                              const d = new Date(v);
-                              return `${d.getHours()}:${String(d.getMinutes()).padStart(2, "0")}`;
-                            }}
-                          />
-                          <YAxis
-                            domain={[0, 100]}
-                            tick={{ fill: "rgba(255,255,255,0.3)", fontSize: 11 }}
-                            tickLine={false}
-                            axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
-                            width={40}
-                            tickFormatter={(v: number) => `${v}%`}
-                          />
-                          <Tooltip
-                            content={({ active, payload }) =>
-                              active && payload?.length ? (
-                                <div className="hm-chart-tooltip">
-                                  <span>{payload[0].value}%</span>
-                                </div>
-                              ) : null
-                            }
-                          />
-                          <ReferenceLine
-                            y={50}
-                            stroke="rgba(255,255,255,0.06)"
-                            strokeDasharray="4 4"
-                          />
-                          <Line
-                            type="monotone"
-                            dataKey="pct"
-                            stroke="#e5b84a"
-                            strokeWidth={2}
-                            dot={false}
-                            isAnimationActive
-                          />
-                        </LineChart>
-                      </ResponsiveContainer>
+                    <div className="hm-chart-container" ref={chartContainerRef}>
+                      {chartReady ? (
+                        <ResponsiveContainer width="100%" height="100%">
+                          <LineChart data={effChartData}>
+                            <XAxis
+                              dataKey="time"
+                              tick={{
+                                fill: "rgba(255,255,255,0.3)",
+                                fontSize: 11,
+                              }}
+                              tickLine={false}
+                              axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
+                              tickFormatter={(v: number) => {
+                                const d = new Date(v);
+                                return `${d.getHours()}:${String(d.getMinutes()).padStart(2, "0")}`;
+                              }}
+                            />
+                            <YAxis
+                              domain={[0, 100]}
+                              tick={{
+                                fill: "rgba(255,255,255,0.3)",
+                                fontSize: 11,
+                              }}
+                              tickLine={false}
+                              axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
+                              width={40}
+                              tickFormatter={(v: number) => `${v}%`}
+                            />
+                            <Tooltip
+                              content={({ active, payload }) =>
+                                active && payload?.length ? (
+                                  <div className="hm-chart-tooltip">
+                                    <span>{payload[0].value}%</span>
+                                  </div>
+                                ) : null
+                              }
+                            />
+                            <ReferenceLine
+                              y={50}
+                              stroke="rgba(255,255,255,0.06)"
+                              strokeDasharray="4 4"
+                            />
+                            <Line
+                              type="monotone"
+                              dataKey="pct"
+                              stroke="#e5b84a"
+                              strokeWidth={2}
+                              dot={false}
+                              isAnimationActive
+                            />
+                          </LineChart>
+                        </ResponsiveContainer>
+                      ) : null}
                     </div>
                   </div>
                 )}

--- a/packages/hyperbet-bsc/app/src/lib/config.ts
+++ b/packages/hyperbet-bsc/app/src/lib/config.ts
@@ -77,6 +77,53 @@ function uniqueList(values: string[]): string[] {
   return unique;
 }
 
+function parseStreamSourceUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function isHyperscapeStreamSource(value: string): boolean {
+  const parsed = parseStreamSourceUrl(value);
+  if (!parsed) return false;
+
+  const pathname = parsed.pathname.toLowerCase();
+  const page = (parsed.searchParams.get("page") || "").trim().toLowerCase();
+  const isStreamRoute =
+    pathname.endsWith("/stream") ||
+    pathname === "/stream" ||
+    pathname.endsWith("/stream.html") ||
+    pathname === "/stream.html" ||
+    page === "stream";
+
+  return (
+    isStreamRoute &&
+    (parsed.searchParams.has("streamToken") ||
+      parsed.hostname.toLowerCase().includes("hyperscape"))
+  );
+}
+
+function sanitizeResolvedStreamSources(values: string[]): string[] {
+  const uniqueSources = uniqueList(values);
+  if (!uniqueSources.some(isHyperscapeStreamSource)) {
+    return uniqueSources;
+  }
+
+  const retainedSources = uniqueSources.filter(isHyperscapeStreamSource);
+  const droppedSources = uniqueSources.filter(
+    (source) => !isHyperscapeStreamSource(source),
+  );
+  if (droppedSources.length > 0 && typeof console !== "undefined") {
+    console.warn(
+      "[config] dropping non-Hyperscapes fallback streams while a tokenized Hyperscapes stream is configured",
+      droppedSources,
+    );
+  }
+  return retainedSources;
+}
+
 function resolveEnvironment(): Environment {
   const explicitCluster = readEnvString("VITE_SOLANA_CLUSTER")?.toLowerCase();
   if (explicitCluster && ENVIRONMENT_ALIASES[explicitCluster]) {
@@ -276,7 +323,7 @@ interface EnvConfig {
 const DEFAULT_STREAM_URL = "https://www.twitch.tv/hyperscapeai";
 const DEFAULT_STREAM_FALLBACK_URL = "";
 const DEFAULT_GAME_API_URL = "http://127.0.0.1:5555";
-const DEFAULT_PRODUCTION_GAME_API_URL = "https://bsc-api.hyperbet.win";
+const DEFAULT_PRODUCTION_GAME_API_URL = "https://gold-betting-keeper-production.up.railway.app";
 
 const baseConfig: Partial<EnvConfig> = {
   betWindowSeconds: 300,
@@ -399,19 +446,29 @@ const resolvedGameApiUrl = envGameApiUrl ?? baseEnvConfig.gameApiUrl;
 const envGameWsUrl = readEnvString("VITE_GAME_WS_URL");
 const resolvedGameWsUrl =
   envGameWsUrl ?? `${resolvedGameApiUrl.replace(/^http/, "ws")}/ws`;
+const envStreamUrl = readEnvString("VITE_STREAM_URL");
+const envStreamSources = parseEnvList(readEnvString("VITE_STREAM_SOURCES"));
+const suppressDefaultStreamFallback =
+  envStreamUrl == null &&
+  envStreamSources.length === 0 &&
+  envGameApiUrl != null &&
+  envGameApiUrl !== baseEnvConfig.gameApiUrl;
 const defaultPrimaryStreamUrl =
-  readEnvString("VITE_STREAM_URL") ?? baseEnvConfig.streamUrl;
+  envStreamUrl ?? (suppressDefaultStreamFallback ? "" : baseEnvConfig.streamUrl);
 const resolvedStreamSources = (() => {
-  const fromListVar = parseEnvList(readEnvString("VITE_STREAM_SOURCES"));
-  if (fromListVar.length > 0) {
-    return uniqueList(fromListVar);
+  if (envStreamSources.length > 0) {
+    return sanitizeResolvedStreamSources(envStreamSources);
   }
   const envFallbackUrl = readEnvString("VITE_STREAM_FALLBACK_URL");
   const fallbackUrl =
     envFallbackUrl ??
-    (defaultPrimaryStreamUrl ? DEFAULT_STREAM_FALLBACK_URL : "");
-  return uniqueList([defaultPrimaryStreamUrl, fallbackUrl ?? ""]).filter(
-    (value) => value.length > 0,
+    (defaultPrimaryStreamUrl && !suppressDefaultStreamFallback
+      ? DEFAULT_STREAM_FALLBACK_URL
+      : "");
+  return sanitizeResolvedStreamSources(
+    uniqueList([defaultPrimaryStreamUrl, fallbackUrl ?? ""]).filter(
+      (value) => value.length > 0,
+    ),
   );
 })();
 const resolvedStreamUrl = resolvedStreamSources[0] ?? "";

--- a/packages/hyperbet-bsc/keeper/src/service.ts
+++ b/packages/hyperbet-bsc/keeper/src/service.ts
@@ -140,6 +140,11 @@ type RateBucket = {
   lastRefillMs: number;
 };
 
+type RateLimitResult = {
+  allowed: boolean;
+  retryAfterSeconds: number;
+};
+
 type JsonRpcRequestPayload = Record<string, unknown> & {
   method: string;
 };
@@ -1664,9 +1669,12 @@ function checkRateLimit(
   pathname: string,
   limitPerMinute: number,
   burst: number,
-): boolean {
+): RateLimitResult {
   if (DISABLE_RATE_LIMIT) {
-    return true;
+    return {
+      allowed: true,
+      retryAfterSeconds: 0,
+    };
   }
 
   const now = Date.now();
@@ -1689,12 +1697,23 @@ function checkRateLimit(
 
   if (bucket.tokens < 1) {
     rateBuckets.set(key, bucket);
-    return false;
+    const deficit = 1 - bucket.tokens;
+    const retryAfterSeconds = Math.max(
+      1,
+      Math.ceil((deficit * 60) / limitPerMinute),
+    );
+    return {
+      allowed: false,
+      retryAfterSeconds,
+    };
   }
 
   bucket.tokens -= 1;
   rateBuckets.set(key, bucket);
-  return true;
+  return {
+    allowed: true,
+    retryAfterSeconds: 0,
+  };
 }
 
 function requireWriteAuth(
@@ -3090,14 +3109,24 @@ const server = Bun.serve({
   fetch: async (req: Request) => {
     const url = new URL(req.url);
     const isWriteRoute = isWriteRateLimitedRoute(req.method, url.pathname);
-    const allowed = checkRateLimit(
+    const rateLimit = checkRateLimit(
       req,
       url.pathname,
       isWriteRoute ? WRITE_RATE_LIMIT_PER_MINUTE : READ_RATE_LIMIT_PER_MINUTE,
       isWriteRoute ? WRITE_RATE_LIMIT_BURST : READ_RATE_LIMIT_BURST,
     );
-    if (!allowed) {
-      return jsonResponse(req, { error: "Rate limit exceeded" }, 429);
+    if (!rateLimit.allowed) {
+      return jsonResponse(
+        req,
+        {
+          error: "Rate limit exceeded",
+          retryAfterSeconds: rateLimit.retryAfterSeconds,
+        },
+        429,
+        {
+          "retry-after": String(rateLimit.retryAfterSeconds),
+        },
+      );
     }
 
     if (req.method === "OPTIONS") {

--- a/packages/hyperbet-solana/app/src/App.tsx
+++ b/packages/hyperbet-solana/app/src/App.tsx
@@ -49,6 +49,7 @@ import { FIGHT_ORACLE_PROGRAM_ID } from "./lib/programIds";
 import { useStreamingState } from "./spectator/useStreamingState";
 import { useDuelContext } from "@hyperbet/ui/spectator/useDuelContext";
 import type { LeaderboardEntry } from "./spectator/types";
+import { useMeasuredContentBox } from "@hyperbet/ui/lib/useMeasuredContentBox";
 import { useResizePanel, useIsMobile } from "@hyperbet/ui/lib/useResizePanel";
 import { ResizeHandle } from "@hyperbet/ui/components/ResizeHandle";
 import {
@@ -57,7 +58,6 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
   ReferenceLine,
 } from "recharts";
 
@@ -745,6 +745,8 @@ export function App() {
   >("leaderboard");
   const appRootRef = useRef<HTMLDivElement | null>(null);
   const bettingDockInnerRef = useRef<HTMLDivElement | null>(null);
+  const chartContainerRef = useRef<HTMLDivElement | null>(null);
+  const chartSize = useMeasuredContentBox(chartContainerRef, !isMobile, 2);
 
   const { state: streamingState } = useStreamingState();
   const { context: duelContext } = useDuelContext();
@@ -1757,70 +1759,76 @@ export function App() {
                 </div>
 
                 {/* Odds Chart */}
-                <div className="hm-chart-panel">
-                  <div className="hm-chart-toolbar">
-                    <button className="hm-chart-tool-btn" type="button">
-                      +
-                    </button>
-                    <button className="hm-chart-tool-btn" type="button">
-                      &#9881;
-                    </button>
-                    <button className="hm-chart-tool-btn" type="button">
-                      &#9634;
-                    </button>
+                {!isMobile && (
+                  <div className="hm-chart-panel">
+                    <div className="hm-chart-toolbar">
+                      <button className="hm-chart-tool-btn" type="button">
+                        +
+                      </button>
+                      <button className="hm-chart-tool-btn" type="button">
+                        &#9881;
+                      </button>
+                      <button className="hm-chart-tool-btn" type="button">
+                        &#9634;
+                      </button>
+                    </div>
+                    <div className="hm-chart-price-label">
+                      <span className="hm-chart-price-current">
+                        {(effYesPercent / 100).toFixed(1)}
+                      </span>
+                    </div>
+                    <div className="hm-chart-container" ref={chartContainerRef}>
+                      {chartSize ? (
+                        <LineChart
+                          data={effChartData}
+                          width={chartSize.width}
+                          height={chartSize.height}
+                        >
+                          <XAxis
+                            dataKey="time"
+                            tick={{ fill: "rgba(255,255,255,0.3)", fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
+                            tickFormatter={(v: number) => {
+                              const d = new Date(v);
+                              return `${d.getHours()}:${String(d.getMinutes()).padStart(2, "0")}`;
+                            }}
+                          />
+                          <YAxis
+                            domain={[0, 100]}
+                            tick={{ fill: "rgba(255,255,255,0.3)", fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
+                            width={40}
+                            tickFormatter={(v: number) => `${v}%`}
+                          />
+                          <Tooltip
+                            content={({ active, payload }) =>
+                              active && payload?.length ? (
+                                <div className="hm-chart-tooltip">
+                                  <span>{payload[0].value}%</span>
+                                </div>
+                              ) : null
+                            }
+                          />
+                          <ReferenceLine
+                            y={50}
+                            stroke="rgba(255,255,255,0.06)"
+                            strokeDasharray="4 4"
+                          />
+                          <Line
+                            type="monotone"
+                            dataKey="pct"
+                            stroke="#e5b84a"
+                            strokeWidth={2}
+                            dot={false}
+                            isAnimationActive
+                          />
+                        </LineChart>
+                      ) : null}
+                    </div>
                   </div>
-                  <div className="hm-chart-price-label">
-                    <span className="hm-chart-price-current">
-                      {(effYesPercent / 100).toFixed(1)}
-                    </span>
-                  </div>
-                  <div className="hm-chart-container">
-                    <ResponsiveContainer width="100%" height="100%">
-                      <LineChart data={effChartData}>
-                        <XAxis
-                          dataKey="time"
-                          tick={{ fill: "rgba(255,255,255,0.3)", fontSize: 11 }}
-                          tickLine={false}
-                          axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
-                          tickFormatter={(v: number) => {
-                            const d = new Date(v);
-                            return `${d.getHours()}:${String(d.getMinutes()).padStart(2, "0")}`;
-                          }}
-                        />
-                        <YAxis
-                          domain={[0, 100]}
-                          tick={{ fill: "rgba(255,255,255,0.3)", fontSize: 11 }}
-                          tickLine={false}
-                          axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
-                          width={40}
-                          tickFormatter={(v: number) => `${v}%`}
-                        />
-                        <Tooltip
-                          content={({ active, payload }) =>
-                            active && payload?.length ? (
-                              <div className="hm-chart-tooltip">
-                                <span>{payload[0].value}%</span>
-                              </div>
-                            ) : null
-                          }
-                        />
-                        <ReferenceLine
-                          y={50}
-                          stroke="rgba(255,255,255,0.06)"
-                          strokeDasharray="4 4"
-                        />
-                        <Line
-                          type="monotone"
-                          dataKey="pct"
-                          stroke="#e5b84a"
-                          strokeWidth={2}
-                          dot={false}
-                          isAnimationActive
-                        />
-                      </LineChart>
-                    </ResponsiveContainer>
-                  </div>
-                </div>
+                )}
               </div>
 
               <ResizeHandle

--- a/packages/hyperbet-solana/app/src/lib/config.ts
+++ b/packages/hyperbet-solana/app/src/lib/config.ts
@@ -72,6 +72,53 @@ function uniqueList(values: string[]): string[] {
   return unique;
 }
 
+function parseStreamSourceUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+function isHyperscapeStreamSource(value: string): boolean {
+  const parsed = parseStreamSourceUrl(value);
+  if (!parsed) return false;
+
+  const pathname = parsed.pathname.toLowerCase();
+  const page = (parsed.searchParams.get("page") || "").trim().toLowerCase();
+  const isStreamRoute =
+    pathname.endsWith("/stream") ||
+    pathname === "/stream" ||
+    pathname.endsWith("/stream.html") ||
+    pathname === "/stream.html" ||
+    page === "stream";
+
+  return (
+    isStreamRoute &&
+    (parsed.searchParams.has("streamToken") ||
+      parsed.hostname.toLowerCase().includes("hyperscape"))
+  );
+}
+
+function sanitizeResolvedStreamSources(values: string[]): string[] {
+  const uniqueSources = uniqueList(values);
+  if (!uniqueSources.some(isHyperscapeStreamSource)) {
+    return uniqueSources;
+  }
+
+  const retainedSources = uniqueSources.filter(isHyperscapeStreamSource);
+  const droppedSources = uniqueSources.filter(
+    (source) => !isHyperscapeStreamSource(source),
+  );
+  if (droppedSources.length > 0 && typeof console !== "undefined") {
+    console.warn(
+      "[config] dropping non-Hyperscapes fallback streams while a tokenized Hyperscapes stream is configured",
+      droppedSources,
+    );
+  }
+  return retainedSources;
+}
+
 function resolveEnvironment(): Environment {
   const explicitCluster = readEnvString("VITE_SOLANA_CLUSTER")?.toLowerCase();
   if (explicitCluster && ENVIRONMENT_ALIASES[explicitCluster]) {
@@ -182,7 +229,7 @@ export interface EnvConfig {
 const DEFAULT_STREAM_URL = "https://www.twitch.tv/hyperscapeai";
 const DEFAULT_STREAM_FALLBACK_URL = "";
 const DEFAULT_GAME_API_URL = "http://127.0.0.1:5555";
-const DEFAULT_PRODUCTION_GAME_API_URL = "https://api.hyperbet.win";
+const DEFAULT_PRODUCTION_GAME_API_URL = "https://gold-betting-keeper-production.up.railway.app";
 
 const baseConfig: Partial<EnvConfig> = {
   betWindowSeconds: 300,
@@ -295,19 +342,29 @@ const resolvedGameApiUrl = envGameApiUrl ?? baseEnvConfig.gameApiUrl;
 const envGameWsUrl = readEnvString("VITE_GAME_WS_URL");
 const resolvedGameWsUrl =
   envGameWsUrl ?? `${resolvedGameApiUrl.replace(/^http/, "ws")}/ws`;
+const envStreamUrl = readEnvString("VITE_STREAM_URL");
+const envStreamSources = parseEnvList(readEnvString("VITE_STREAM_SOURCES"));
+const suppressDefaultStreamFallback =
+  envStreamUrl == null &&
+  envStreamSources.length === 0 &&
+  envGameApiUrl != null &&
+  envGameApiUrl !== baseEnvConfig.gameApiUrl;
 const defaultPrimaryStreamUrl =
-  readEnvString("VITE_STREAM_URL") ?? baseEnvConfig.streamUrl;
+  envStreamUrl ?? (suppressDefaultStreamFallback ? "" : baseEnvConfig.streamUrl);
 const resolvedStreamSources = (() => {
-  const fromListVar = parseEnvList(readEnvString("VITE_STREAM_SOURCES"));
-  if (fromListVar.length > 0) {
-    return uniqueList(fromListVar);
+  if (envStreamSources.length > 0) {
+    return sanitizeResolvedStreamSources(envStreamSources);
   }
   const envFallbackUrl = readEnvString("VITE_STREAM_FALLBACK_URL");
   const fallbackUrl =
     envFallbackUrl ??
-    (defaultPrimaryStreamUrl ? DEFAULT_STREAM_FALLBACK_URL : "");
-  return uniqueList([defaultPrimaryStreamUrl, fallbackUrl ?? ""]).filter(
-    (value) => value.length > 0,
+    (defaultPrimaryStreamUrl && !suppressDefaultStreamFallback
+      ? DEFAULT_STREAM_FALLBACK_URL
+      : "");
+  return sanitizeResolvedStreamSources(
+    uniqueList([defaultPrimaryStreamUrl, fallbackUrl ?? ""]).filter(
+      (value) => value.length > 0,
+    ),
   );
 })();
 const resolvedStreamUrl = resolvedStreamSources[0] ?? "";

--- a/packages/hyperbet-ui/src/components/EvmBettingPanel.tsx
+++ b/packages/hyperbet-ui/src/components/EvmBettingPanel.tsx
@@ -37,14 +37,13 @@ import {
   createEvmPublicClient,
   createSignedRpcWalletClient,
   createUnlockedRpcWalletClient,
-  getFeeBps,
   getMarketMeta,
+  getMarketReadSnapshot,
   getNativeBalance,
-  getOrderBook,
-  getPosition,
   getRecentTrades,
   ORDER_FLAG_GTC,
   placeOrder,
+  RateLimitError,
   toDuelKeyHex,
   type MarketMeta,
   type MarketStatus,
@@ -77,6 +76,7 @@ import { type Trade } from "./RecentTrades";
 type BetSide = "YES" | "NO";
 
 const MARKET_KIND_DUEL_WINNER = 0;
+const MIN_RPC_BACKOFF_MS = 15_000;
 
 function createStrictPrivateKeyAccount(
   address: Address,
@@ -392,6 +392,14 @@ function getLifecycleStatusLabel(
   }
 }
 
+function toRateLimitError(error: unknown): RateLimitError | null {
+  return error instanceof RateLimitError ? error : null;
+}
+
+function describeRefreshError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function EvmBettingPanel({
   agent1Name,
   agent2Name,
@@ -525,6 +533,9 @@ export function EvmBettingPanel({
   );
 
   const lastSnapshotRef = useRef<{ a: bigint; b: bigint }>({ a: 0n, b: 0n });
+  const refreshDataRef = useRef<() => Promise<void>>(async () => {});
+  const refreshDataInFlightRef = useRef<Promise<void> | null>(null);
+  const rpcBackoffUntilRef = useRef(0);
 
   const cycle = streamingState?.cycle ?? null;
   const streamedDuelKeyHex =
@@ -696,6 +707,45 @@ export function EvmBettingPanel({
   const refreshData = useCallback(async () => {
     if (!publicClient || !chainConfig) return;
 
+    const applyRateLimitBackoff = (error: unknown): boolean => {
+      const rateLimitError = toRateLimitError(error);
+      if (!rateLimitError) return false;
+      rpcBackoffUntilRef.current = Math.max(
+        rpcBackoffUntilRef.current,
+        Date.now() + Math.max(rateLimitError.retryAfterMs, MIN_RPC_BACKOFF_MS),
+      );
+      setLastRefreshError(rateLimitError.message);
+      return true;
+    };
+
+    const updateStatusFromMarket = (market: MarketMeta, nextPosition: Position | null) => {
+      const nextUiState = derivePredictionMarketUiState(
+        activeLifecycleMarket,
+        nextPosition
+          ? {
+              aShares: nextPosition.aShares,
+              bShares: nextPosition.bShares,
+              aStake: nextPosition.aStake,
+              bStake: nextPosition.bStake,
+              refundableAmount: nextPosition.aStake + nextPosition.bStake,
+            }
+          : EMPTY_PREDICTION_MARKET_WALLET_SNAPSHOT,
+        {
+          lifecycleStatus: getFallbackLifecycleStatus(market.status),
+          winner: getFallbackWinner(market.winner),
+        },
+      );
+      setStatus(
+        getLifecycleStatusLabel(
+          nextUiState.lifecycleStatus,
+          nextUiState.winner,
+          cycleAgent1,
+          cycleAgent2,
+          copy,
+        ) ?? copy.waitingForMarketOperator,
+      );
+    };
+
     try {
       if (!duelKeyHex) {
         setLastRefreshError("missing-duel-key");
@@ -730,115 +780,75 @@ export function EvmBettingPanel({
       setMarketMeta(market);
       setLastRefreshError(null);
       updateChartAndTrades(market.totalAShares, market.totalBShares);
-      const feeBpsPromise = getFeeBps(publicClient, contractAddr);
-      const orderBookPromise = getOrderBook(
-        publicClient,
+
+      if (!effectiveAddress) {
+        setPosition(null);
+        setNativeBalance(0n);
+        updateStatusFromMarket(market, null);
+      } else {
+        updateStatusFromMarket(market, effectivePosition);
+      }
+
+      if (Date.now() < rpcBackoffUntilRef.current) {
+        return;
+      }
+
+      const marketReadPromise = getMarketReadSnapshot(
+        chainConfig,
         contractAddr,
         duelKey,
         MARKET_KIND_DUEL_WINNER,
         market,
+        effectiveAddress,
       );
       const tradesPromise = getRecentTrades(
         publicClient,
         contractAddr,
         market.marketKey,
       );
+      const balancePromise = effectiveAddress
+        ? getNativeBalance(publicClient, effectiveAddress)
+        : Promise.resolve(0n);
 
-      if (effectiveAddress) {
-        const [userPosition, balance] = await Promise.all([
-          getPosition(
-            publicClient,
-            contractAddr,
-            market.marketKey,
-            effectiveAddress,
-          ),
-          getNativeBalance(publicClient, effectiveAddress),
-        ]);
-        setPosition(userPosition);
-        setOptimisticPosition((current) => {
-          if (!current) return null;
-          const hasCaughtUp =
-            userPosition.aShares >= current.aShares &&
-            userPosition.bShares >= current.bShares &&
-            userPosition.aStake >= current.aStake &&
-            userPosition.bStake >= current.bStake;
-          return hasCaughtUp ? null : current;
-        });
-        setNativeBalance(balance);
-        const nextUiState = derivePredictionMarketUiState(
-          activeLifecycleMarket,
-          {
-            aShares: userPosition.aShares,
-            bShares: userPosition.bShares,
-            aStake: userPosition.aStake,
-            bStake: userPosition.bStake,
-            refundableAmount: userPosition.aStake + userPosition.bStake,
-          },
-          {
-            lifecycleStatus: getFallbackLifecycleStatus(market.status),
-            winner: getFallbackWinner(market.winner),
-          },
-        );
-        setStatus(
-          getLifecycleStatusLabel(
-            nextUiState.lifecycleStatus,
-            nextUiState.winner,
-            cycleAgent1,
-            cycleAgent2,
-            copy,
-          ) ?? copy.waitingForMarketOperator,
-        );
-      } else {
-        setPosition(null);
-        setNativeBalance(0n);
-        const nextUiState = derivePredictionMarketUiState(
-          activeLifecycleMarket,
-          EMPTY_PREDICTION_MARKET_WALLET_SNAPSHOT,
-          {
-            lifecycleStatus: getFallbackLifecycleStatus(market.status),
-            winner: getFallbackWinner(market.winner),
-          },
-        );
-        setStatus(
-          getLifecycleStatusLabel(
-            nextUiState.lifecycleStatus,
-            nextUiState.winner,
-            cycleAgent1,
-            cycleAgent2,
-            copy,
-          ) ?? copy.waitingForMarketOperator,
-        );
-      }
-
-      const [feeBpsResult, orderBookResult, tradesResult] =
+      const [marketReadResult, tradesResult, balanceResult] =
         await Promise.allSettled([
-          feeBpsPromise,
-          orderBookPromise,
+          marketReadPromise,
           tradesPromise,
+          balancePromise,
         ]);
 
-      if (feeBpsResult.status === "fulfilled") {
-        setTradeFeeBps(feeBpsResult.value);
-      }
-
-      if (orderBookResult.status === "fulfilled") {
+      if (marketReadResult.status === "fulfilled") {
+        setTradeFeeBps(marketReadResult.value.feeBps);
         setBids(
-          orderBookResult.value.bids.map((entry) => ({
+          marketReadResult.value.orderBook.bids.map((entry) => ({
             price: entry.price,
             amount: Number(formatUnits(entry.amount, nativeDecimals)),
             total: Number(formatUnits(entry.total, nativeDecimals)),
           })),
         );
         setAsks(
-          orderBookResult.value.asks.map((entry) => ({
+          marketReadResult.value.orderBook.asks.map((entry) => ({
             price: entry.price,
             amount: Number(formatUnits(entry.amount, nativeDecimals)),
             total: Number(formatUnits(entry.total, nativeDecimals)),
           })),
         );
-      } else {
-        setBids([]);
-        setAsks([]);
+        if (effectiveAddress && marketReadResult.value.position) {
+          const userPosition = marketReadResult.value.position;
+          setPosition(userPosition);
+          setOptimisticPosition((current) => {
+            if (!current) return null;
+            const hasCaughtUp =
+              userPosition.aShares >= current.aShares &&
+              userPosition.bShares >= current.bShares &&
+              userPosition.aStake >= current.aStake &&
+              userPosition.bStake >= current.bStake;
+            return hasCaughtUp ? null : current;
+          });
+          updateStatusFromMarket(market, userPosition);
+        }
+      } else if (!applyRateLimitBackoff(marketReadResult.reason)) {
+        setLastRefreshError(describeRefreshError(marketReadResult.reason));
       }
 
       if (tradesResult.status === "fulfilled") {
@@ -851,10 +861,19 @@ export function EvmBettingPanel({
             time: trade.time,
           })),
         );
-      } else {
-        setRecentTrades([]);
+      } else if (!applyRateLimitBackoff(tradesResult.reason)) {
+        setLastRefreshError(describeRefreshError(tradesResult.reason));
+      }
+
+      if (balanceResult.status === "fulfilled") {
+        setNativeBalance(balanceResult.value);
+      } else if (!applyRateLimitBackoff(balanceResult.reason)) {
+        setLastRefreshError(describeRefreshError(balanceResult.reason));
       }
     } catch (error) {
+      if (applyRateLimitBackoff(error)) {
+        return;
+      }
       const message = (error as Error).message;
       setLastRefreshError(message);
       setStatus(copy.refreshFailed(message));
@@ -866,6 +885,7 @@ export function EvmBettingPanel({
     cycleAgent2,
     duelKeyHex,
     effectiveAddress,
+    effectivePosition,
     activeLifecycleMarket,
     lifecycleStatusLabel,
     nativeDecimals,

--- a/packages/hyperbet-ui/src/components/ModelsMarketView.tsx
+++ b/packages/hyperbet-ui/src/components/ModelsMarketView.tsx
@@ -14,7 +14,6 @@ import {
   Line,
   LineChart,
   ReferenceLine,
-  ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
@@ -45,6 +44,7 @@ import {
   resolveUiLocale,
   type UiLocale,
 } from "@hyperbet/ui/i18n";
+import { useMeasuredContentBox } from "../lib/useMeasuredContentBox";
 
 const PROGRAM_ID = new PublicKey(
   CONFIG.goldPerpsMarketProgramId || goldPerpsIdl.address,
@@ -721,8 +721,11 @@ export function ModelsMarketView({
     string | null
   >(null);
   const oracleHistoryChartRef = React.useRef<HTMLDivElement | null>(null);
-  const [oracleHistoryChartReady, setOracleHistoryChartReady] =
-    React.useState(false);
+  const oracleHistoryChartSize = useMeasuredContentBox(
+    oracleHistoryChartRef,
+    true,
+    2,
+  );
   const effectiveLeverage = Math.min(
     configuredMaxLeverage,
     Math.max(1, Math.round(leverage)),
@@ -739,33 +742,6 @@ export function ModelsMarketView({
   );
   const openCollateralSatisfiesMinMargin =
     estimatedOpenPostFeeMarginLamports >= configuredMinMarginLamports;
-
-  React.useEffect(() => {
-    const container = oracleHistoryChartRef.current;
-    if (!container) return;
-
-    const updateChartReady = () => {
-      const nextReady =
-        container.clientWidth > 0 && container.clientHeight > 0;
-      setOracleHistoryChartReady((prevReady) =>
-        prevReady === nextReady ? prevReady : nextReady,
-      );
-    };
-
-    updateChartReady();
-
-    const resizeObserver =
-      typeof ResizeObserver !== "undefined"
-        ? new ResizeObserver(updateChartReady)
-        : null;
-    resizeObserver?.observe(container);
-
-    window.addEventListener("resize", updateChartReady);
-    return () => {
-      resizeObserver?.disconnect();
-      window.removeEventListener("resize", updateChartReady);
-    };
-  }, []);
 
   React.useEffect(() => {
     if (E2E_MODEL_ENTRY) {
@@ -1802,80 +1778,81 @@ export function ModelsMarketView({
                     <div className="models-market-empty">
                       {copy.waitingForSnapshots}
                     </div>
-                  ) : oracleHistoryChartReady ? (
-                    <ResponsiveContainer width="100%" height="100%">
-                      <LineChart data={oracleHistory}>
-                        <XAxis
-                          dataKey="label"
-                          tick={{
-                            fill: "rgba(255,255,255,0.45)",
-                            fontSize: 11,
-                          }}
-                          tickLine={false}
-                          axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
-                        />
-                        <YAxis
-                          tick={{
-                            fill: "rgba(255,255,255,0.45)",
-                            fontSize: 11,
-                          }}
-                          tickLine={false}
-                          axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
-                          width={48}
-                          tickFormatter={(value: number) =>
-                            formatUsd(value, locale, 0)
-                          }
-                        />
-                        <Tooltip
-                          content={({ active, payload }) => {
-                            if (!active || !payload?.length) return null;
-                            const point = payload[0]
-                              ?.payload as OracleHistoryPoint;
-                            return (
-                              <div className="models-market-tooltip">
-                                <strong>{formatUsd(point.spotIndex, locale)}</strong>
-                                <span>
-                                  {copy.skill}{" "}
-                                  {formatLocaleNumber(
-                                    point.conservativeSkill,
-                                    locale,
-                                    {
-                                      minimumFractionDigits: 2,
-                                      maximumFractionDigits: 2,
-                                    },
-                                  )}{" "}
-                                  · μ{" "}
-                                  {formatLocaleNumber(point.mu, locale, {
+                  ) : oracleHistoryChartSize ? (
+                    <LineChart
+                      data={oracleHistory}
+                      width={oracleHistoryChartSize.width}
+                      height={oracleHistoryChartSize.height}
+                    >
+                      <XAxis
+                        dataKey="label"
+                        tick={{
+                          fill: "rgba(255,255,255,0.45)",
+                          fontSize: 11,
+                        }}
+                        tickLine={false}
+                        axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
+                      />
+                      <YAxis
+                        tick={{
+                          fill: "rgba(255,255,255,0.45)",
+                          fontSize: 11,
+                        }}
+                        tickLine={false}
+                        axisLine={{ stroke: "rgba(255,255,255,0.08)" }}
+                        width={48}
+                        tickFormatter={(value: number) =>
+                          formatUsd(value, locale, 0)
+                        }
+                      />
+                      <Tooltip
+                        content={({ active, payload }) => {
+                          if (!active || !payload?.length) return null;
+                          const point = payload[0]?.payload as OracleHistoryPoint;
+                          return (
+                            <div className="models-market-tooltip">
+                              <strong>{formatUsd(point.spotIndex, locale)}</strong>
+                              <span>
+                                {copy.skill}{" "}
+                                {formatLocaleNumber(
+                                  point.conservativeSkill,
+                                  locale,
+                                  {
                                     minimumFractionDigits: 2,
                                     maximumFractionDigits: 2,
-                                  })}{" "}
-                                  · σ{" "}
-                                  {formatLocaleNumber(point.sigma, locale, {
-                                    minimumFractionDigits: 2,
-                                    maximumFractionDigits: 2,
-                                  })}
-                                </span>
-                              </div>
-                            );
-                          }}
+                                  },
+                                )}{" "}
+                                · μ{" "}
+                                {formatLocaleNumber(point.mu, locale, {
+                                  minimumFractionDigits: 2,
+                                  maximumFractionDigits: 2,
+                                })}{" "}
+                                · σ{" "}
+                                {formatLocaleNumber(point.sigma, locale, {
+                                  minimumFractionDigits: 2,
+                                  maximumFractionDigits: 2,
+                                })}
+                              </span>
+                            </div>
+                          );
+                        }}
+                      />
+                      {selectedMarket?.spotIndex && (
+                        <ReferenceLine
+                          y={selectedMarket.spotIndex}
+                          stroke="rgba(229,184,74,0.2)"
+                          strokeDasharray="4 4"
                         />
-                        {selectedMarket?.spotIndex && (
-                          <ReferenceLine
-                            y={selectedMarket.spotIndex}
-                            stroke="rgba(229,184,74,0.2)"
-                            strokeDasharray="4 4"
-                          />
-                        )}
-                        <Line
-                          type="monotone"
-                          dataKey="spotIndex"
-                          stroke="#e5b84a"
-                          strokeWidth={2}
-                          dot={false}
-                          isAnimationActive={false}
-                        />
-                      </LineChart>
-                    </ResponsiveContainer>
+                      )}
+                      <Line
+                        type="monotone"
+                        dataKey="spotIndex"
+                        stroke="#e5b84a"
+                        strokeWidth={2}
+                        dot={false}
+                        isAnimationActive={false}
+                      />
+                    </LineChart>
                   ) : null}
                 </div>
               </div>

--- a/packages/hyperbet-ui/src/components/ModelsMarketView.tsx
+++ b/packages/hyperbet-ui/src/components/ModelsMarketView.tsx
@@ -720,6 +720,9 @@ export function ModelsMarketView({
   const [oracleHistoryError, setOracleHistoryError] = React.useState<
     string | null
   >(null);
+  const oracleHistoryChartRef = React.useRef<HTMLDivElement | null>(null);
+  const [oracleHistoryChartReady, setOracleHistoryChartReady] =
+    React.useState(false);
   const effectiveLeverage = Math.min(
     configuredMaxLeverage,
     Math.max(1, Math.round(leverage)),
@@ -736,6 +739,33 @@ export function ModelsMarketView({
   );
   const openCollateralSatisfiesMinMargin =
     estimatedOpenPostFeeMarginLamports >= configuredMinMarginLamports;
+
+  React.useEffect(() => {
+    const container = oracleHistoryChartRef.current;
+    if (!container) return;
+
+    const updateChartReady = () => {
+      const nextReady =
+        container.clientWidth > 0 && container.clientHeight > 0;
+      setOracleHistoryChartReady((prevReady) =>
+        prevReady === nextReady ? prevReady : nextReady,
+      );
+    };
+
+    updateChartReady();
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(updateChartReady)
+        : null;
+    resizeObserver?.observe(container);
+
+    window.addEventListener("resize", updateChartReady);
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", updateChartReady);
+    };
+  }, []);
 
   React.useEffect(() => {
     if (E2E_MODEL_ENTRY) {
@@ -1756,7 +1786,10 @@ export function ModelsMarketView({
                   </span>
                 </div>
 
-                <div className="models-market-history-chart">
+                <div
+                  className="models-market-history-chart"
+                  ref={oracleHistoryChartRef}
+                >
                   {oracleHistoryError ? (
                     <div className="models-market-empty">
                       {copy.oracleHistoryError(oracleHistoryError)}
@@ -1769,7 +1802,7 @@ export function ModelsMarketView({
                     <div className="models-market-empty">
                       {copy.waitingForSnapshots}
                     </div>
-                  ) : (
+                  ) : oracleHistoryChartReady ? (
                     <ResponsiveContainer width="100%" height="100%">
                       <LineChart data={oracleHistory}>
                         <XAxis
@@ -1843,7 +1876,7 @@ export function ModelsMarketView({
                         />
                       </LineChart>
                     </ResponsiveContainer>
-                  )}
+                  ) : null}
                 </div>
               </div>
 

--- a/packages/hyperbet-ui/src/components/PredictionMarketPanel.tsx
+++ b/packages/hyperbet-ui/src/components/PredictionMarketPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, ReactNode } from "react";
+import { useEffect, useRef, useState, ReactNode } from "react";
 import { getUiCopy, resolveUiLocale, type UiLocale } from "@hyperbet/ui/i18n";
 import {
   LineChart,
@@ -88,6 +88,8 @@ export function PredictionMarketPanel({
   const resolvedLocale = resolveUiLocale(locale);
   const copy = getUiCopy(resolvedLocale);
   const [activeTab, setActiveTab] = useState<"buy" | "sell">("buy");
+  const chartContainerRef = useRef<HTMLDivElement | null>(null);
+  const [chartReady, setChartReady] = useState(false);
 
   const yesSelected = side === "YES";
   const noSelected = side === "NO";
@@ -118,6 +120,33 @@ export function PredictionMarketPanel({
   const C_YES_BAR = compact
     ? "linear-gradient(90deg, var(--hm-buy-soft, rgba(34,197,94,0.2)), var(--hm-buy), var(--hm-buy-soft, rgba(34,197,94,0.2)))"
     : "linear-gradient(90deg, var(--hm-buy-soft, rgba(34,197,94,0.2)), var(--hm-buy), var(--hm-buy-soft, rgba(34,197,94,0.2)))";
+
+  useEffect(() => {
+    const container = chartContainerRef.current;
+    if (!container) return;
+
+    const updateChartReady = () => {
+      const nextReady =
+        container.clientWidth > 0 && container.clientHeight > 0;
+      setChartReady((prevReady) =>
+        prevReady === nextReady ? prevReady : nextReady,
+      );
+    };
+
+    updateChartReady();
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(updateChartReady)
+        : null;
+    resizeObserver?.observe(container);
+
+    window.addEventListener("resize", updateChartReady);
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", updateChartReady);
+    };
+  }, []);
   const C_YES_BAR_SHADOW = compact
     ? "0 0 8px var(--hm-buy-glow-strong, rgba(34,197,94,0.5))"
     : "0 0 8px var(--hm-buy-glow-strong, rgba(34,197,94,0.5))";
@@ -893,6 +922,7 @@ export function PredictionMarketPanel({
                 />
               </div>
               <div
+                ref={chartContainerRef}
                 style={{
                   flex: 1,
                   minHeight: 0,
@@ -900,71 +930,74 @@ export function PredictionMarketPanel({
                   zIndex: 1,
                 }}
               >
-                <ResponsiveContainer width="100%" height="100%">
-                  <LineChart data={chartData}>
-                    <defs>
-                      <filter
-                        id="glow"
-                        x="-20%"
-                        y="-20%"
-                        width="140%"
-                        height="140%"
-                      >
-                        <feGaussianBlur stdDeviation="3" result="blur" />
-                        <feComposite
-                          in="SourceGraphic"
-                          in2="blur"
-                          operator="over"
-                        />
-                      </filter>
-                    </defs>
-                    <XAxis dataKey="time" hide />
-                    <YAxis domain={[0, 100]} hide />
-                    <Tooltip
-                      content={({ active, payload }) => {
-                        if (active && payload && payload.length) {
-                          return (
-                            <div
-                              style={{
-                                background: "rgba(10,12,18,0.7)",
-                                backdropFilter: "blur(20px)",
-                                WebkitBackdropFilter: "blur(20px)",
-                                padding: "6px 12px",
-                                borderRadius: 8,
-                                border: "1px solid var(--hm-chip-border, rgba(232,65,66,0.3))",
-                                fontSize: 13,
-                                fontFamily: "var(--hm-font-mono)",
-                                fontWeight: 900,
-                                color: "#fff",
-                                boxShadow:
-                                  "0 4px 20px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.08)",
-                              }}
-                            >
-                              <span style={{ color: "var(--hm-accent-gold)" }}>
-                                {payload[0].value}%
-                              </span>
-                            </div>
-                          );
-                        }
-                        return null;
-                      }}
-                    />
-                    <ReferenceLine
-                      y={50}
-                      stroke="rgba(255,255,255,0.1)"
-                      strokeDasharray="4 4"
-                    />
-                    <Line
-                      type="monotone"
-                      dataKey="pct"
-                      stroke="var(--hm-buy)"
-                      strokeWidth={3}
-                      dot={false}
-                      isAnimationActive={true}
-                      filter="url(#glow)"
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
+                {chartReady ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={chartData}>
+                      <defs>
+                        <filter
+                          id="glow"
+                          x="-20%"
+                          y="-20%"
+                          width="140%"
+                          height="140%"
+                        >
+                          <feGaussianBlur stdDeviation="3" result="blur" />
+                          <feComposite
+                            in="SourceGraphic"
+                            in2="blur"
+                            operator="over"
+                          />
+                        </filter>
+                      </defs>
+                      <XAxis dataKey="time" hide />
+                      <YAxis domain={[0, 100]} hide />
+                      <Tooltip
+                        content={({ active, payload }) => {
+                          if (active && payload && payload.length) {
+                            return (
+                              <div
+                                style={{
+                                  background: "rgba(10,12,18,0.7)",
+                                  backdropFilter: "blur(20px)",
+                                  WebkitBackdropFilter: "blur(20px)",
+                                  padding: "6px 12px",
+                                  borderRadius: 8,
+                                  border:
+                                    "1px solid var(--hm-chip-border, rgba(232,65,66,0.3))",
+                                  fontSize: 13,
+                                  fontFamily: "var(--hm-font-mono)",
+                                  fontWeight: 900,
+                                  color: "#fff",
+                                  boxShadow:
+                                    "0 4px 20px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.08)",
+                                }}
+                              >
+                                <span style={{ color: "var(--hm-accent-gold)" }}>
+                                  {payload[0].value}%
+                                </span>
+                              </div>
+                            );
+                          }
+                          return null;
+                        }}
+                      />
+                      <ReferenceLine
+                        y={50}
+                        stroke="rgba(255,255,255,0.1)"
+                        strokeDasharray="4 4"
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey="pct"
+                        stroke="var(--hm-buy)"
+                        strokeWidth={3}
+                        dot={false}
+                        isAnimationActive={true}
+                        filter="url(#glow)"
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                ) : null}
               </div>
             </div>
 

--- a/packages/hyperbet-ui/src/components/PredictionMarketPanel.tsx
+++ b/packages/hyperbet-ui/src/components/PredictionMarketPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, ReactNode } from "react";
+import { useRef, useState, ReactNode } from "react";
 import { getUiCopy, resolveUiLocale, type UiLocale } from "@hyperbet/ui/i18n";
 import {
   LineChart,
@@ -6,9 +6,9 @@ import {
   XAxis,
   YAxis,
   Tooltip,
-  ResponsiveContainer,
   ReferenceLine,
 } from "recharts";
+import { useMeasuredContentBox } from "../lib/useMeasuredContentBox";
 import { OrderBook, type OrderLevel } from "./OrderBook";
 import { RecentTrades, type Trade } from "./RecentTrades";
 
@@ -89,7 +89,7 @@ export function PredictionMarketPanel({
   const copy = getUiCopy(resolvedLocale);
   const [activeTab, setActiveTab] = useState<"buy" | "sell">("buy");
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
-  const [chartReady, setChartReady] = useState(false);
+  const chartSize = useMeasuredContentBox(chartContainerRef, true, 2);
 
   const yesSelected = side === "YES";
   const noSelected = side === "NO";
@@ -121,32 +121,6 @@ export function PredictionMarketPanel({
     ? "linear-gradient(90deg, var(--hm-buy-soft, rgba(34,197,94,0.2)), var(--hm-buy), var(--hm-buy-soft, rgba(34,197,94,0.2)))"
     : "linear-gradient(90deg, var(--hm-buy-soft, rgba(34,197,94,0.2)), var(--hm-buy), var(--hm-buy-soft, rgba(34,197,94,0.2)))";
 
-  useEffect(() => {
-    const container = chartContainerRef.current;
-    if (!container) return;
-
-    const updateChartReady = () => {
-      const nextReady =
-        container.clientWidth > 0 && container.clientHeight > 0;
-      setChartReady((prevReady) =>
-        prevReady === nextReady ? prevReady : nextReady,
-      );
-    };
-
-    updateChartReady();
-
-    const resizeObserver =
-      typeof ResizeObserver !== "undefined"
-        ? new ResizeObserver(updateChartReady)
-        : null;
-    resizeObserver?.observe(container);
-
-    window.addEventListener("resize", updateChartReady);
-    return () => {
-      resizeObserver?.disconnect();
-      window.removeEventListener("resize", updateChartReady);
-    };
-  }, []);
   const C_YES_BAR_SHADOW = compact
     ? "0 0 8px var(--hm-buy-glow-strong, rgba(34,197,94,0.5))"
     : "0 0 8px var(--hm-buy-glow-strong, rgba(34,197,94,0.5))";
@@ -930,73 +904,75 @@ export function PredictionMarketPanel({
                   zIndex: 1,
                 }}
               >
-                {chartReady ? (
-                  <ResponsiveContainer width="100%" height="100%">
-                    <LineChart data={chartData}>
-                      <defs>
-                        <filter
-                          id="glow"
-                          x="-20%"
-                          y="-20%"
-                          width="140%"
-                          height="140%"
-                        >
-                          <feGaussianBlur stdDeviation="3" result="blur" />
-                          <feComposite
-                            in="SourceGraphic"
-                            in2="blur"
-                            operator="over"
-                          />
-                        </filter>
-                      </defs>
-                      <XAxis dataKey="time" hide />
-                      <YAxis domain={[0, 100]} hide />
-                      <Tooltip
-                        content={({ active, payload }) => {
-                          if (active && payload && payload.length) {
-                            return (
-                              <div
-                                style={{
-                                  background: "rgba(10,12,18,0.7)",
-                                  backdropFilter: "blur(20px)",
-                                  WebkitBackdropFilter: "blur(20px)",
-                                  padding: "6px 12px",
-                                  borderRadius: 8,
-                                  border:
-                                    "1px solid var(--hm-chip-border, rgba(232,65,66,0.3))",
-                                  fontSize: 13,
-                                  fontFamily: "var(--hm-font-mono)",
-                                  fontWeight: 900,
-                                  color: "#fff",
-                                  boxShadow:
-                                    "0 4px 20px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.08)",
-                                }}
-                              >
-                                <span style={{ color: "var(--hm-accent-gold)" }}>
-                                  {payload[0].value}%
-                                </span>
-                              </div>
-                            );
-                          }
-                          return null;
-                        }}
-                      />
-                      <ReferenceLine
-                        y={50}
-                        stroke="rgba(255,255,255,0.1)"
-                        strokeDasharray="4 4"
-                      />
-                      <Line
-                        type="monotone"
-                        dataKey="pct"
-                        stroke="var(--hm-buy)"
-                        strokeWidth={3}
-                        dot={false}
-                        isAnimationActive={true}
-                        filter="url(#glow)"
-                      />
-                    </LineChart>
-                  </ResponsiveContainer>
+                {chartSize ? (
+                  <LineChart
+                    data={chartData}
+                    width={chartSize.width}
+                    height={chartSize.height}
+                  >
+                    <defs>
+                      <filter
+                        id="glow"
+                        x="-20%"
+                        y="-20%"
+                        width="140%"
+                        height="140%"
+                      >
+                        <feGaussianBlur stdDeviation="3" result="blur" />
+                        <feComposite
+                          in="SourceGraphic"
+                          in2="blur"
+                          operator="over"
+                        />
+                      </filter>
+                    </defs>
+                    <XAxis dataKey="time" hide />
+                    <YAxis domain={[0, 100]} hide />
+                    <Tooltip
+                      content={({ active, payload }) => {
+                        if (active && payload && payload.length) {
+                          return (
+                            <div
+                              style={{
+                                background: "rgba(10,12,18,0.7)",
+                                backdropFilter: "blur(20px)",
+                                WebkitBackdropFilter: "blur(20px)",
+                                padding: "6px 12px",
+                                borderRadius: 8,
+                                border:
+                                  "1px solid var(--hm-chip-border, rgba(232,65,66,0.3))",
+                                fontSize: 13,
+                                fontFamily: "var(--hm-font-mono)",
+                                fontWeight: 900,
+                                color: "#fff",
+                                boxShadow:
+                                  "0 4px 20px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.08)",
+                              }}
+                            >
+                              <span style={{ color: "var(--hm-accent-gold)" }}>
+                                {payload[0].value}%
+                              </span>
+                            </div>
+                          );
+                        }
+                        return null;
+                      }}
+                    />
+                    <ReferenceLine
+                      y={50}
+                      stroke="rgba(255,255,255,0.1)"
+                      strokeDasharray="4 4"
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="pct"
+                      stroke="var(--hm-buy)"
+                      strokeWidth={3}
+                      dot={false}
+                      isAnimationActive={true}
+                      filter="url(#glow)"
+                    />
+                  </LineChart>
                 ) : null}
               </div>
             </div>

--- a/packages/hyperbet-ui/src/components/StreamPlayer.tsx
+++ b/packages/hyperbet-ui/src/components/StreamPlayer.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import Hls from "hls.js";
 
 interface StreamPlayerProps {
@@ -27,22 +33,88 @@ export const StreamPlayer: React.FC<StreamPlayerProps> = ({
     () => resolveEmbedUrl(streamUrl, autoPlay, muted),
     [autoPlay, muted, streamUrl],
   );
+  const embedKind = useMemo(() => classifyEmbedKind(embedUrl), [embedUrl]);
   const unavailableNotifiedRef = useRef(false);
+  const readyNotifiedRef = useRef(false);
+  const [embedFailure, setEmbedFailure] = useState<string | null>(null);
 
-  const markUnavailable = useCallback(() => {
-    if (unavailableNotifiedRef.current) return;
-    unavailableNotifiedRef.current = true;
-    onStreamUnavailable?.();
-  }, [onStreamUnavailable]);
+  const markUnavailable = useCallback(
+    (reason = "Live stream unavailable.") => {
+      setEmbedFailure((current) => current ?? reason);
+      if (unavailableNotifiedRef.current) return;
+      unavailableNotifiedRef.current = true;
+      onStreamUnavailable?.();
+    },
+    [onStreamUnavailable],
+  );
+
+  const markReady = useCallback(() => {
+    setEmbedFailure(null);
+    if (readyNotifiedRef.current) return;
+    readyNotifiedRef.current = true;
+    onStreamReady?.();
+  }, [onStreamReady]);
 
   useEffect(() => {
     unavailableNotifiedRef.current = false;
+    readyNotifiedRef.current = false;
+    setEmbedFailure(null);
   }, [streamUrl]);
 
   useEffect(() => {
     if (embedUrl) return;
     markUnavailable();
   }, [embedUrl, markUnavailable]);
+
+  useEffect(() => {
+    if (!embedUrl || embedKind !== "hyperscape" || typeof window === "undefined") {
+      return;
+    }
+
+    const embedOrigin = getEmbedOrigin(embedUrl);
+    if (!embedOrigin) {
+      return;
+    }
+
+    let seenStatusMessage = false;
+    const bootstrapTimeout = window.setTimeout(() => {
+      if (!seenStatusMessage) {
+        markUnavailable("Failed to initialize the embedded Hyperscapes stream.");
+      }
+    }, 10_000);
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== embedOrigin) return;
+      if (!event.data || typeof event.data !== "object") return;
+
+      const payload = event.data as {
+        type?: string;
+        ready?: boolean;
+        status?: string | null;
+      };
+      if (payload.type !== "HYPERSCAPE_STREAM_STATUS") {
+        return;
+      }
+
+      seenStatusMessage = true;
+      window.clearTimeout(bootstrapTimeout);
+
+      if (payload.ready === true) {
+        markReady();
+        return;
+      }
+
+      if (typeof payload.status === "string" && payload.status.startsWith("error:")) {
+        markUnavailable(describeHyperscapeEmbedError(payload.status));
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => {
+      window.clearTimeout(bootstrapTimeout);
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [embedKind, embedUrl, markReady, markUnavailable]);
 
   useEffect(() => {
     // External embeddable URLs render through iframe mode below.
@@ -220,7 +292,7 @@ export const StreamPlayer: React.FC<StreamPlayerProps> = ({
 
         hls.on(Hls.Events.MANIFEST_PARSED, () => {
           console.log("[StreamPlayer] Manifest parsed, starting playback");
-          onStreamReady?.();
+          markReady();
           void video.play().catch(() => {});
         });
 
@@ -269,7 +341,7 @@ export const StreamPlayer: React.FC<StreamPlayerProps> = ({
 
     const onWaiting = () => nudgeToLiveEdge();
     const onStalled = () => nudgeToLiveEdge();
-    const onLoadedMetadata = () => onStreamReady?.();
+    const onLoadedMetadata = () => markReady();
     const onVideoError = () => scheduleRebuild("video element error", 1000);
 
     video.addEventListener("waiting", onWaiting);
@@ -296,7 +368,7 @@ export const StreamPlayer: React.FC<StreamPlayerProps> = ({
         hls = null;
       }
     };
-  }, [embedUrl, streamUrl, autoPlay, muted]);
+  }, [embedUrl, streamUrl, autoPlay, muted, markReady]);
 
   if (!embedUrl) {
     return (
@@ -350,9 +422,9 @@ export const StreamPlayer: React.FC<StreamPlayerProps> = ({
         allow="autoplay; encrypted-media; picture-in-picture; clipboard-write"
         allowFullScreen
         loading="eager"
-        onLoad={onStreamReady}
+        onLoad={embedKind === "hyperscape" ? undefined : markReady}
         referrerPolicy="strict-origin-when-cross-origin"
-        onError={markUnavailable}
+        onError={() => markUnavailable()}
         style={{
           width: "100%",
           height: "100%",
@@ -361,6 +433,39 @@ export const StreamPlayer: React.FC<StreamPlayerProps> = ({
           backgroundColor: "#000",
         }}
       />
+      {embedFailure ? (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            zIndex: 1,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "24px",
+            textAlign: "center",
+            color: "#f3e4ba",
+            fontFamily: "system-ui, sans-serif",
+            fontSize: "0.95rem",
+            lineHeight: 1.5,
+            background:
+              "linear-gradient(180deg, rgba(2,4,10,0.76), rgba(2,4,10,0.88))",
+          }}
+        >
+          <div
+            style={{
+              maxWidth: "28rem",
+              padding: "1rem 1.25rem",
+              border: "1px solid rgba(243, 228, 186, 0.28)",
+              borderRadius: "0.9rem",
+              backgroundColor: "rgba(8, 11, 20, 0.72)",
+              boxShadow: "0 16px 48px rgba(0, 0, 0, 0.28)",
+            }}
+          >
+            {embedFailure}
+          </div>
+        </div>
+      ) : null}
       <div
         style={{
           position: "absolute",
@@ -465,6 +570,47 @@ function toTwitchEmbedUrl(
   embed.searchParams.set("autoplay", autoPlay ? "true" : "false");
   embed.searchParams.set("muted", muted ? "true" : "false");
   return embed.toString();
+}
+
+function classifyEmbedKind(embedUrl: string | null): "generic" | "hyperscape" {
+  if (!embedUrl) return "generic";
+
+  const parsed = parseUrl(embedUrl);
+  if (!parsed) return "generic";
+
+  const pathname = parsed.pathname.toLowerCase();
+  const page = (parsed.searchParams.get("page") || "").trim().toLowerCase();
+  const isStreamRoute =
+    pathname.endsWith("/stream") ||
+    pathname === "/stream" ||
+    pathname.endsWith("/stream.html") ||
+    pathname === "/stream.html" ||
+    page === "stream";
+
+  if (!isStreamRoute) return "generic";
+  if (parsed.searchParams.has("streamToken")) return "hyperscape";
+  if (parsed.hostname.toLowerCase().includes("hyperscape")) return "hyperscape";
+  return "generic";
+}
+
+function getEmbedOrigin(embedUrl: string): string | null {
+  const parsed = parseUrl(embedUrl);
+  return parsed?.origin ?? null;
+}
+
+function describeHyperscapeEmbedError(status: string): string {
+  switch (status) {
+    case "error:viewer_access_denied":
+      return "Live stream access is currently restricted for this page.";
+    case "error:webgpu_required":
+      return "This browser cannot render the live 3D stream.";
+    case "error:http":
+      return "The live stream is temporarily unavailable.";
+    case "error:init_failed":
+      return "Failed to initialize the live 3D stream.";
+    default:
+      return "Live stream unavailable.";
+  }
 }
 
 function parseUrl(rawValue: string): URL | null {

--- a/packages/hyperbet-ui/src/lib/evmClient.ts
+++ b/packages/hyperbet-ui/src/lib/evmClient.ts
@@ -2,6 +2,7 @@ import {
   createPublicClient,
   createWalletClient,
   custom,
+  decodeFunctionResult,
   encodeAbiParameters,
   encodeFunctionData,
   fallback,
@@ -55,6 +56,21 @@ export type Position = {
   bStake: bigint;
 };
 
+export type OrderBookLevel = {
+  price: number;
+  amount: bigint;
+  total: bigint;
+};
+
+export type MarketReadSnapshot = {
+  feeBps: number;
+  position: Position | null;
+  orderBook: {
+    bids: OrderBookLevel[];
+    asks: OrderBookLevel[];
+  };
+};
+
 export type TimeInForce = "gtc" | "ioc";
 
 export type OrderInfo = {
@@ -77,9 +93,29 @@ export type ContractWriteClient = {
 export type ContractWriteAccount = Address | Account;
 
 type JsonRpcPayload<T> = {
+  id?: number | string | null;
   result?: T;
   error?: { message?: string };
 };
+
+type GoldClobBatchRead = {
+  functionName:
+    | "tradeTreasuryFeeBps"
+    | "tradeMarketMakerFeeBps"
+    | "positions"
+    | "getPriceLevel";
+  args?: readonly unknown[];
+};
+
+export class RateLimitError extends Error {
+  readonly retryAfterMs: number;
+
+  constructor(message = "Rate limit exceeded", retryAfterMs = 15_000) {
+    super(message);
+    this.name = "RateLimitError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
 
 export const SIDE_ENUM = {
   NONE: 0,
@@ -142,9 +178,13 @@ function deriveAlchemyWsUrl(rpcUrl: string): string | null {
   }
 }
 
+function isProxyReadRpcUrl(rpcUrl: string): boolean {
+  return rpcUrl.includes("/api/proxy/evm/rpc");
+}
+
 function createEvmTransport(rpcUrl: string) {
   const httpTransport = http(rpcUrl, {
-    retryCount: 5,
+    retryCount: isProxyReadRpcUrl(rpcUrl) ? 0 : 5,
     retryDelay: 250,
     timeout: 20_000,
   });
@@ -258,6 +298,100 @@ async function callEvmRpc<T>(
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
       throw new Error(`${method} timed out after 15000ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function parseRetryAfterMs(rawValue: string | null): number | null {
+  if (!rawValue) return null;
+  const seconds = Number(rawValue);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.max(1_000, Math.ceil(seconds * 1_000));
+  }
+
+  const retryAtMs = Date.parse(rawValue);
+  if (!Number.isNaN(retryAtMs)) {
+    return Math.max(1_000, retryAtMs - Date.now());
+  }
+  return null;
+}
+
+function rateLimitErrorFromResponse(response: Response): RateLimitError {
+  return new RateLimitError(
+    "EVM read rate limited",
+    parseRetryAfterMs(response.headers.get("retry-after")) ?? 15_000,
+  );
+}
+
+async function callGoldClobBatchRead(
+  rpcUrl: string,
+  contractAddress: Address,
+  calls: readonly GoldClobBatchRead[],
+): Promise<unknown[]> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15_000);
+
+  try {
+    const payload = calls.map((call, index) => ({
+      jsonrpc: "2.0" as const,
+      id: index,
+      method: "eth_call",
+      params: [
+        {
+          to: contractAddress,
+          data: encodeFunctionData({
+            abi: GOLD_CLOB_ABI,
+            functionName: call.functionName,
+            args: (call.args ?? []) as readonly unknown[],
+          } as unknown as Parameters<typeof encodeFunctionData>[0]),
+        },
+        "latest",
+      ],
+    }));
+    const response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    if (response.status === 429) {
+      throw rateLimitErrorFromResponse(response);
+    }
+
+    const body = (await response.json()) as JsonRpcPayload<Hex>[];
+    if (!response.ok || !Array.isArray(body)) {
+      throw new Error("eth_call batch failed");
+    }
+
+    const byId = new Map<number, JsonRpcPayload<Hex>>();
+    for (const entry of body) {
+      const id = Number(entry.id);
+      if (Number.isInteger(id)) {
+        byId.set(id, entry);
+      }
+    }
+
+    return calls.map((call, index) => {
+      const entry = byId.get(index);
+      if (!entry) {
+        throw new Error(`${call.functionName} missing from eth_call batch`);
+      }
+      if (entry.result === undefined) {
+        throw new Error(entry.error?.message || `${call.functionName} failed`);
+      }
+      return decodeFunctionResult({
+        abi: GOLD_CLOB_ABI,
+        functionName: call.functionName,
+        data: entry.result,
+      } as unknown as Parameters<typeof decodeFunctionResult>[0]);
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error("eth_call batch timed out after 15000ms");
     }
     throw error;
   } finally {
@@ -389,6 +523,92 @@ export async function getMarketMeta(
     totalAShares: result.totalAShares,
     totalBShares: result.totalBShares,
     marketKey: resolvedMarketKey,
+  };
+}
+
+export async function getMarketReadSnapshot(
+  chainConfig: EvmChainConfig,
+  contractAddress: Address,
+  duelKey: Hex,
+  marketKind: number,
+  market: MarketMeta,
+  userAddress?: Address,
+): Promise<MarketReadSnapshot> {
+  const calls: GoldClobBatchRead[] = [
+    { functionName: "tradeTreasuryFeeBps" },
+    { functionName: "tradeMarketMakerFeeBps" },
+  ];
+  const hasUserAddress = Boolean(userAddress);
+  if (userAddress) {
+    calls.push({
+      functionName: "positions",
+      args: [market.marketKey, userAddress],
+    });
+  }
+
+  const bidPrices: number[] = [];
+  for (let price = market.bestBid; price > 0 && bidPrices.length < 10; price -= 1) {
+    bidPrices.push(price);
+    calls.push({
+      functionName: "getPriceLevel",
+      args: [duelKey, marketKind, SIDE_ENUM.BUY, price],
+    });
+  }
+
+  const askPrices: number[] = [];
+  for (let price = market.bestAsk; price < 1000 && askPrices.length < 10; price += 1) {
+    askPrices.push(price);
+    calls.push({
+      functionName: "getPriceLevel",
+      args: [duelKey, marketKind, SIDE_ENUM.SELL, price],
+    });
+  }
+
+  const results = await callGoldClobBatchRead(
+    chainConfig.readRpcUrl,
+    contractAddress,
+    calls,
+  );
+
+  let nextIndex = 0;
+  const treasuryFee = results[nextIndex++] as bigint;
+  const marketMakerFee = results[nextIndex++] as bigint;
+  const position = hasUserAddress
+    ? ((results[nextIndex++] as [bigint, bigint, bigint, bigint]) ?? null)
+    : null;
+
+  const bids: OrderBookLevel[] = [];
+  let runningBid = 0n;
+  for (const price of bidPrices) {
+    const level = results[nextIndex++] as [bigint, bigint, bigint];
+    if (level[2] <= 0n) continue;
+    runningBid += level[2];
+    bids.push({ price: price / 1000, amount: level[2], total: runningBid });
+  }
+
+  const asks: OrderBookLevel[] = [];
+  let runningAsk = 0n;
+  for (const price of askPrices) {
+    const level = results[nextIndex++] as [bigint, bigint, bigint];
+    if (level[2] <= 0n) continue;
+    runningAsk += level[2];
+    asks.push({ price: price / 1000, amount: level[2], total: runningAsk });
+  }
+
+  return {
+    feeBps: Number(treasuryFee + marketMakerFee),
+    position: position
+      ? {
+          aShares: position[0],
+          bShares: position[1],
+          aStake: position[2],
+          bStake: position[3],
+        }
+      : null,
+    orderBook: {
+      bids,
+      asks,
+    },
   };
 }
 

--- a/packages/hyperbet-ui/src/lib/useMeasuredContentBox.ts
+++ b/packages/hyperbet-ui/src/lib/useMeasuredContentBox.ts
@@ -1,0 +1,94 @@
+import { type RefObject, useEffect, useState } from "react";
+
+type ContentBoxSize = {
+  width: number;
+  height: number;
+};
+
+function parseCssPixels(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function measureContentBox(element: HTMLElement): ContentBoxSize | null {
+  const style = window.getComputedStyle(element);
+  const horizontalPadding =
+    parseCssPixels(style.paddingLeft) + parseCssPixels(style.paddingRight);
+  const verticalPadding =
+    parseCssPixels(style.paddingTop) + parseCssPixels(style.paddingBottom);
+  const width = Math.max(0, element.clientWidth - horizontalPadding);
+  const height = Math.max(0, element.clientHeight - verticalPadding);
+
+  if (width <= 0 || height <= 0) {
+    return null;
+  }
+
+  return { width, height };
+}
+
+export function useMeasuredContentBox<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  enabled = true,
+  settleFrames = 1,
+): ContentBoxSize | null {
+  const [size, setSize] = useState<ContentBoxSize | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setSize(null);
+      return;
+    }
+
+    const element = ref.current;
+    if (!element || typeof window === "undefined") {
+      setSize(null);
+      return;
+    }
+
+    let firstFrame = 0;
+    let secondFrame = 0;
+
+    const update = () => {
+      setSize((current) => {
+        const next = measureContentBox(element);
+        if (!current || !next) {
+          return next;
+        }
+        return current.width === next.width && current.height === next.height
+          ? current
+          : next;
+      });
+    };
+
+    const scheduleUpdate = () => {
+      window.cancelAnimationFrame(firstFrame);
+      window.cancelAnimationFrame(secondFrame);
+      firstFrame = window.requestAnimationFrame(() => {
+        if (settleFrames > 1) {
+          secondFrame = window.requestAnimationFrame(update);
+          return;
+        }
+        update();
+      });
+    };
+
+    scheduleUpdate();
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(scheduleUpdate)
+        : null;
+    resizeObserver?.observe(element);
+
+    window.addEventListener("resize", scheduleUpdate);
+
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      window.cancelAnimationFrame(secondFrame);
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleUpdate);
+    };
+  }, [enabled, ref, settleFrames]);
+
+  return size;
+}

--- a/packages/hyperbet-ui/src/styles.css
+++ b/packages/hyperbet-ui/src/styles.css
@@ -3028,6 +3028,9 @@ select:focus-visible {
 
 .hm-chart-container {
   flex: 1;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
   min-height: 0;
   padding: 8px;
 }


### PR DESCRIPTION
## Summary
- port the generic staging fixes for stream embedding, HLS player hardening, and market chart sizing into `develop`
- include the BSC RPC backoff/mobile chart guard changes that were already validated on `enoomian/staging`
- keep personal Enoomian staging deploy tooling and env-specific scripts out of this PR

## Included in this PR
- stream source/config hardening for Solana and BSC app embeds
- shared `StreamPlayer` hardening
- chart mount/sizing stabilization across Solana, BSC, prediction, and models views
- EVM betting panel/RPC backoff changes from staging
- shared measured content box hook

## Explicitly excluded
- `scripts/enoomian-staging/*`
- personal staging proof/soak/deploy script changes from `local/enoomian-staging-tools`
- uncommitted local runtime/renderer work from the dirty main worktree

## Verification
- `bun x tsc --noEmit -p packages/hyperbet-ui/tsconfig.verify.json`
- `bun run --cwd packages/hyperbet-solana/app build --mode mainnet-beta`
- `bun run --cwd packages/hyperbet-bsc/app build --mode mainnet-beta`