### PR TITLE
Split AVAX parity follow-up out of #130

### DIFF
--- a/packages/hyperbet-avax/app/hls-player.html
+++ b/packages/hyperbet-avax/app/hls-player.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no,viewport-fit=cover"
+    />
+    <title>Hyperscape Live Stream</title>
+    <meta name="theme-color" content="#0b0a15" />
+    <style>
+      html,
+      body,
+      #root {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        background-color: #0b0a15;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/hlsPlayerMain.tsx"></script>
+  </body>
+</html>

--- a/packages/hyperbet-avax/app/src/hlsPlayerMain.tsx
+++ b/packages/hyperbet-avax/app/src/hlsPlayerMain.tsx
@@ -1,0 +1,3 @@
+import { mountHlsPlayerApp } from "@hyperbet/ui/player";
+
+mountHlsPlayerApp(document.getElementById("root")!);

--- a/packages/hyperbet-avax/app/vite.config.ts
+++ b/packages/hyperbet-avax/app/vite.config.ts
@@ -409,6 +409,10 @@ export default defineConfig(async ({ mode }) => {
       sourcemap: env.VITE_BUILD_SOURCEMAP === "true",
       chunkSizeWarningLimit: 3000,
       rollupOptions: {
+        input: {
+          index: path.resolve(__dirname, "index.html"),
+          "hls-player": path.resolve(__dirname, "hls-player.html"),
+        },
         onwarn(warning, warn) {
           if (
             warning.code === "SOURCEMAP_ERROR" ||

--- a/packages/hyperbet-avax/keeper/src/bot.ts
+++ b/packages/hyperbet-avax/keeper/src/bot.ts
@@ -2024,7 +2024,6 @@ async function upsertDuelLifecycle(
 ): Promise<PublicKey> {
   const duelKey = duelKeyHexToBytes(data.duelKeyHex);
   const duelState = findDuelStatePda(fightProgram.programId, duelKey);
-  const nowSeconds = Math.floor(Date.now() / 1000);
   const betOpenTs = Math.floor((data.betOpenTime ?? Date.now()) / 1000);
   const betCloseTs = Math.max(
     betOpenTs + 1,
@@ -2036,9 +2035,6 @@ async function upsertDuelLifecycle(
     betCloseTs,
     Math.floor((data.fightStartTime ?? data.betCloseTime ?? Date.now()) / 1000),
   );
-  const requestedStatus =
-    status === "scheduled" && betOpenTs <= nowSeconds ? "bettingOpen" : status;
-
   await runWithRecovery(
     () =>
       fightProgram.methods
@@ -2050,7 +2046,7 @@ async function upsertDuelLifecycle(
           new BN(betCloseTs),
           new BN(duelStartTs),
           buildDuelMetadata(data),
-          duelStatusEnum(requestedStatus),
+          duelStatusEnum(status),
         )
         .accountsPartial({
           reporter: botKeypair.publicKey,

--- a/packages/hyperbet-avax/keeper/src/idl/fight_oracle.json
+++ b/packages/hyperbet-avax/keeper/src/idl/fight_oracle.json
@@ -1,5 +1,5 @@
 {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fight_oracle",
     "version": "0.1.0",
@@ -343,7 +343,7 @@
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "program_data"
@@ -1051,12 +1051,12 @@
     {
       "code": 6021,
       "name": "ParticipantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "TimingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-avax/keeper/src/idl/fight_oracle.ts
+++ b/packages/hyperbet-avax/keeper/src/idl/fight_oracle.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/fight_oracle.json`.
  */
 export type FightOracle = {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fightOracle",
     "version": "0.1.0",
@@ -349,7 +349,7 @@ export type FightOracle = {
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "programData"
@@ -1057,12 +1057,12 @@ export type FightOracle = {
     {
       "code": 6021,
       "name": "participantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "timingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-avax/keeper/src/idl/gold_clob_market.json
+++ b/packages/hyperbet-avax/keeper/src/idl/gold_clob_market.json
@@ -1,5 +1,5 @@
 {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "gold_clob_market",
     "version": "0.1.0",
@@ -433,7 +433,7 @@
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "program_data"

--- a/packages/hyperbet-avax/keeper/src/idl/gold_clob_market.ts
+++ b/packages/hyperbet-avax/keeper/src/idl/gold_clob_market.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/gold_clob_market.json`.
  */
 export type GoldClobMarket = {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "goldClobMarket",
     "version": "0.1.0",
@@ -439,7 +439,7 @@ export type GoldClobMarket = {
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "programData"


### PR DESCRIPTION
## Summary
This draft quarantines the AVAX-specific follow-up changes so they do not ride with the active viewer-alignment and contract-scope drafts.

## Includes
- AVAX HLS player entrypoint and app wiring
- AVAX keeper/status artifact updates currently present on the umbrella branch

## Excludes
- active-chain viewer-alignment rollout
- shared contract / registry truth changes for the non-AVAX lanes

## Validation
- split from `enoomian/unified-bets-parity-keepers`
- intentionally kept draft and isolated because AVAX is not part of the current rollout lane