### PR TITLE
Split contract and registry lifecycle parity out of #130

### DIFF
--- a/.github/workflows/prediction-market-gates.yml
+++ b/.github/workflows/prediction-market-gates.yml
@@ -258,6 +258,7 @@ jobs:
         run: bun run dev:bootstrap
 
       - name: Install Playwright browser
+        working-directory: packages/hyperbet-${{ matrix.chain }}/app
         run: bunx playwright install --with-deps chromium
 
       - name: AVAX gate posture note

--- a/packages/evm-contracts/contracts/DuelOutcomeOracle.sol
+++ b/packages/evm-contracts/contracts/DuelOutcomeOracle.sol
@@ -242,8 +242,8 @@ contract DuelOutcomeOracle is AccessControl {
         _requireSettleable(duel);
         if (uint8(status) < uint8(duel.status)) revert InvalidTransition();
 
-        // FIX-4: Lock participant identity and bet timing once betting opens
-        if (duel.status >= DuelStatus.BETTING_OPEN) {
+        // FIX-5: Once a duel is prestaged, its manifest becomes immutable.
+        if (duel.status >= DuelStatus.SCHEDULED) {
             if (participantAHash != duel.participantAHash) revert ParticipantHashImmutable();
             if (participantBHash != duel.participantBHash) revert ParticipantHashImmutable();
             if (betOpenTs != duel.betOpenTs) revert TimingImmutable();

--- a/packages/evm-contracts/contracts/GoldClob.sol
+++ b/packages/evm-contracts/contracts/GoldClob.sol
@@ -305,7 +305,8 @@ contract GoldClob is AccessControl, ReentrancyGuard {
 
         DuelOutcomeOracle.DuelState memory duel = duelOracle.getDuel(duelKey);
         if (
-            duel.status != DuelOutcomeOracle.DuelStatus.BETTING_OPEN
+            duel.status != DuelOutcomeOracle.DuelStatus.SCHEDULED
+                && duel.status != DuelOutcomeOracle.DuelStatus.BETTING_OPEN
                 && duel.status != DuelOutcomeOracle.DuelStatus.LOCKED
         ) revert DuelNotMarketable();
 
@@ -866,6 +867,7 @@ contract GoldClob is AccessControl, ReentrancyGuard {
     }
 
     function _mapDuelStatus(DuelOutcomeOracle.DuelStatus status) internal pure returns (MarketStatus) {
+        if (status == DuelOutcomeOracle.DuelStatus.SCHEDULED) return MarketStatus.LOCKED;
         if (status == DuelOutcomeOracle.DuelStatus.BETTING_OPEN) return MarketStatus.OPEN;
         if (status == DuelOutcomeOracle.DuelStatus.LOCKED) return MarketStatus.LOCKED;
         if (status == DuelOutcomeOracle.DuelStatus.PROPOSED) return MarketStatus.LOCKED;

--- a/packages/evm-contracts/test/GoldClobCanonical.ts
+++ b/packages/evm-contracts/test/GoldClobCanonical.ts
@@ -9,6 +9,7 @@ import {
 } from "../typed-contracts";
 
 const MARKET_KIND_DUEL_WINNER = 0;
+const DUEL_STATUS_SCHEDULED = 1;
 const DUEL_STATUS_BETTING_OPEN = 2;
 const DUEL_STATUS_LOCKED = 3;
 const SIDE_A = 1;
@@ -160,6 +161,101 @@ describe("GoldClob", function () {
     await expect(
       clob.connect(operator).createMarketForDuel(duel, MARKET_KIND_DUEL_WINNER),
     ).to.be.revertedWithCustomError(clob, "MarketExists");
+  });
+
+  it("allows scheduled prestage but keeps the market locked until the oracle opens it", async function () {
+    const { clob, oracle, operator, reporter } = await deployFixture();
+    const duel = duelKey("duel-scheduled");
+    const now = BigInt((await ethers.provider.getBlock("latest"))!.timestamp);
+
+    await oracle
+      .connect(reporter)
+      .upsertDuel(
+        duel,
+        hashParticipant("agent-a"),
+        hashParticipant("agent-b"),
+        now + 30n,
+        now + 90n,
+        now + 150n,
+        "duel-scheduled",
+        DUEL_STATUS_SCHEDULED,
+      );
+
+    await clob
+      .connect(operator)
+      .createMarketForDuel(duel, MARKET_KIND_DUEL_WINNER);
+
+    let market = await clob.getMarket(duel, MARKET_KIND_DUEL_WINNER);
+    expect(market.exists).to.equal(true);
+    expect(market.status).to.equal(2n);
+
+    await oracle
+      .connect(reporter)
+      .upsertDuel(
+        duel,
+        hashParticipant("agent-a"),
+        hashParticipant("agent-b"),
+        now + 30n,
+        now + 90n,
+        now + 150n,
+        "duel-open",
+        DUEL_STATUS_BETTING_OPEN,
+      );
+    await clob.connect(operator).syncMarketFromOracle(duel, MARKET_KIND_DUEL_WINNER);
+
+    market = await clob.getMarket(duel, MARKET_KIND_DUEL_WINNER);
+    expect(market.status).to.equal(1n);
+  });
+
+  it("freezes the scheduled duel manifest after prepare", async function () {
+    const { oracle, reporter } = await deployFixture();
+    const duel = duelKey("duel-scheduled-immutable");
+    const participantA = hashParticipant("agent-a");
+    const participantB = hashParticipant("agent-b");
+    const now = BigInt((await ethers.provider.getBlock("latest"))!.timestamp);
+
+    await oracle
+      .connect(reporter)
+      .upsertDuel(
+        duel,
+        participantA,
+        participantB,
+        now + 30n,
+        now + 90n,
+        now + 150n,
+        "duel-scheduled",
+        DUEL_STATUS_SCHEDULED,
+      );
+
+    await expect(
+      oracle
+        .connect(reporter)
+        .upsertDuel(
+          duel,
+          participantA,
+          participantB,
+          now + 31n,
+          now + 90n,
+          now + 150n,
+          "duel-scheduled-shifted",
+          DUEL_STATUS_SCHEDULED,
+        ),
+    ).to.be.revertedWithCustomError(oracle, "TimingImmutable");
+
+    await expect(
+      oracle
+        .connect(reporter)
+        .upsertDuel(
+          duel,
+          hashParticipant("agent-a-mutated"),
+          participantB,
+          now + 30n,
+          now + 90n,
+          now + 150n,
+          "duel-scheduled-mutated",
+          DUEL_STATUS_SCHEDULED,
+        ),
+    ).to.be.revertedWithCustomError(oracle, "ParticipantHashImmutable");
   });
 
   it("lets the emergency pauser halt new market creation", async function () {

--- a/packages/hyperbet-bsc/app/src/idl/fight_oracle.json
+++ b/packages/hyperbet-bsc/app/src/idl/fight_oracle.json
@@ -1,5 +1,5 @@
 {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fight_oracle",
     "version": "0.1.0",
@@ -343,7 +343,7 @@
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "program_data"
@@ -1051,12 +1051,12 @@
     {
       "code": 6021,
       "name": "ParticipantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "TimingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-bsc/app/src/idl/fight_oracle.ts
+++ b/packages/hyperbet-bsc/app/src/idl/fight_oracle.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/fight_oracle.json`.
  */
 export type FightOracle = {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fightOracle",
     "version": "0.1.0",
@@ -349,7 +349,7 @@ export type FightOracle = {
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "programData"
@@ -1057,12 +1057,12 @@ export type FightOracle = {
     {
       "code": 6021,
       "name": "participantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "timingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-bsc/app/src/idl/gold_clob_market.json
+++ b/packages/hyperbet-bsc/app/src/idl/gold_clob_market.json
@@ -1,5 +1,5 @@
 {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "gold_clob_market",
     "version": "0.1.0",
@@ -433,7 +433,7 @@
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "program_data"

--- a/packages/hyperbet-bsc/app/src/idl/gold_clob_market.ts
+++ b/packages/hyperbet-bsc/app/src/idl/gold_clob_market.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/gold_clob_market.json`.
  */
 export type GoldClobMarket = {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "goldClobMarket",
     "version": "0.1.0",
@@ -439,7 +439,7 @@ export type GoldClobMarket = {
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "programData"

--- a/packages/hyperbet-bsc/keeper/src/idl/fight_oracle.json
+++ b/packages/hyperbet-bsc/keeper/src/idl/fight_oracle.json
@@ -1,5 +1,5 @@
 {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fight_oracle",
     "version": "0.1.0",
@@ -343,7 +343,7 @@
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "program_data"
@@ -1051,12 +1051,12 @@
     {
       "code": 6021,
       "name": "ParticipantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "TimingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-bsc/keeper/src/idl/fight_oracle.ts
+++ b/packages/hyperbet-bsc/keeper/src/idl/fight_oracle.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/fight_oracle.json`.
  */
 export type FightOracle = {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fightOracle",
     "version": "0.1.0",
@@ -349,7 +349,7 @@ export type FightOracle = {
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "programData"
@@ -1057,12 +1057,12 @@ export type FightOracle = {
     {
       "code": 6021,
       "name": "participantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "timingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-bsc/keeper/src/idl/gold_clob_market.json
+++ b/packages/hyperbet-bsc/keeper/src/idl/gold_clob_market.json
@@ -1,5 +1,5 @@
 {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "gold_clob_market",
     "version": "0.1.0",
@@ -433,7 +433,7 @@
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "program_data"

--- a/packages/hyperbet-bsc/keeper/src/idl/gold_clob_market.ts
+++ b/packages/hyperbet-bsc/keeper/src/idl/gold_clob_market.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/gold_clob_market.json`.
  */
 export type GoldClobMarket = {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "goldClobMarket",
     "version": "0.1.0",
@@ -439,7 +439,7 @@ export type GoldClobMarket = {
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "programData"

--- a/packages/hyperbet-chain-registry/src/index.ts
+++ b/packages/hyperbet-chain-registry/src/index.ts
@@ -316,8 +316,8 @@ const SOLANA_DEPLOYMENTS: Record<BettingSolanaCluster, BettingSolanaDeployment> 
   {
     localnet: {
       cluster: "localnet",
-      fightOracleProgramId: "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
-      goldClobMarketProgramId: "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+      fightOracleProgramId: "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
+      goldClobMarketProgramId: "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
       goldPerpsMarketProgramId: "BFbmQbSbf3R6fMDdXKMKQZCTyMhMs9MCcjAhGDBLETXS",
       goldAmmMarketProgramId: "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w",
       goldMint: "DK9nBUMfdu4XprPRWeh8f6KnQiGWD8Z4xz3yzs9gpump",
@@ -325,8 +325,8 @@ const SOLANA_DEPLOYMENTS: Record<BettingSolanaCluster, BettingSolanaDeployment> 
     },
     devnet: {
       cluster: "devnet",
-      fightOracleProgramId: "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
-      goldClobMarketProgramId: "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+      fightOracleProgramId: "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
+      goldClobMarketProgramId: "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
       goldPerpsMarketProgramId: "BFbmQbSbf3R6fMDdXKMKQZCTyMhMs9MCcjAhGDBLETXS",
       goldAmmMarketProgramId: "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w",
       goldMint: "DK9nBUMfdu4XprPRWeh8f6KnQiGWD8Z4xz3yzs9gpump",
@@ -334,8 +334,8 @@ const SOLANA_DEPLOYMENTS: Record<BettingSolanaCluster, BettingSolanaDeployment> 
     },
     testnet: {
       cluster: "testnet",
-      fightOracleProgramId: "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
-      goldClobMarketProgramId: "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+      fightOracleProgramId: "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
+      goldClobMarketProgramId: "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
       goldPerpsMarketProgramId: "BFbmQbSbf3R6fMDdXKMKQZCTyMhMs9MCcjAhGDBLETXS",
       goldAmmMarketProgramId: "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w",
       goldMint: "",

--- a/packages/hyperbet-evm/keeper/src/idl/fight_oracle.json
+++ b/packages/hyperbet-evm/keeper/src/idl/fight_oracle.json
@@ -1,5 +1,5 @@
 {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fight_oracle",
     "version": "0.1.0",
@@ -343,7 +343,7 @@
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "program_data"
@@ -1051,12 +1051,12 @@
     {
       "code": 6021,
       "name": "ParticipantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "TimingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-evm/keeper/src/idl/fight_oracle.ts
+++ b/packages/hyperbet-evm/keeper/src/idl/fight_oracle.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/fight_oracle.json`.
  */
 export type FightOracle = {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fightOracle",
     "version": "0.1.0",
@@ -349,7 +349,7 @@ export type FightOracle = {
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "programData"
@@ -1057,12 +1057,12 @@ export type FightOracle = {
     {
       "code": 6021,
       "name": "participantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "timingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-evm/keeper/src/idl/gold_clob_market.json
+++ b/packages/hyperbet-evm/keeper/src/idl/gold_clob_market.json
@@ -1,5 +1,5 @@
 {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "gold_clob_market",
     "version": "0.1.0",
@@ -433,7 +433,7 @@
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "program_data"

--- a/packages/hyperbet-evm/keeper/src/idl/gold_clob_market.ts
+++ b/packages/hyperbet-evm/keeper/src/idl/gold_clob_market.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/gold_clob_market.json`.
  */
 export type GoldClobMarket = {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "goldClobMarket",
     "version": "0.1.0",
@@ -439,7 +439,7 @@ export type GoldClobMarket = {
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "programData"

--- a/packages/hyperbet-solana/anchor/Anchor.toml
+++ b/packages/hyperbet-solana/anchor/Anchor.toml
@@ -6,20 +6,20 @@ resolution = true
 skip-lint = false
 
 [programs.devnet]
-fight_oracle = "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
-gold_clob_market = "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+fight_oracle = "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
+gold_clob_market = "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
 gold_perps_market = "BFbmQbSbf3R6fMDdXKMKQZCTyMhMs9MCcjAhGDBLETXS"
 lvr_amm = "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
 
 [programs.localnet]
-fight_oracle = "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
-gold_clob_market = "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+fight_oracle = "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
+gold_clob_market = "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
 gold_perps_market = "BFbmQbSbf3R6fMDdXKMKQZCTyMhMs9MCcjAhGDBLETXS"
 lvr_amm = "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
 
 [programs.testnet]
-fight_oracle = "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
-gold_clob_market = "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+fight_oracle = "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
+gold_clob_market = "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
 gold_perps_market = "BFbmQbSbf3R6fMDdXKMKQZCTyMhMs9MCcjAhGDBLETXS"
 lvr_amm = "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
 

--- a/packages/hyperbet-solana/anchor/programs/fight_oracle/src/lib.rs
+++ b/packages/hyperbet-solana/anchor/programs/fight_oracle/src/lib.rs
@@ -3,7 +3,7 @@
 
 use anchor_lang::prelude::*;
 
-declare_id!("GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM");
+declare_id!("7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB");
 
 pub const ORACLE_CONFIG_SEED: &[u8] = b"oracle_config";
 pub const DUEL_SEED: &[u8] = b"duel";
@@ -172,12 +172,13 @@ pub mod fight_oracle {
             duel_state.winner = MarketSide::None;
         }
 
-        // FIX-4: Lock participant identity and bet timing once betting opens
-        if is_initialized && duel_status_rank(duel_state.status) >= duel_status_rank(DuelStatus::BettingOpen) {
+        // FIX-5: Once a duel is prestaged, its manifest becomes immutable.
+        if is_initialized {
             require!(participant_a_hash == duel_state.participant_a_hash, ErrorCode::ParticipantHashImmutable);
             require!(participant_b_hash == duel_state.participant_b_hash, ErrorCode::ParticipantHashImmutable);
             require!(bet_open_ts == duel_state.bet_open_ts, ErrorCode::TimingImmutable);
             require!(bet_close_ts == duel_state.bet_close_ts, ErrorCode::TimingImmutable);
+            require!(duel_start_ts == duel_state.duel_start_ts, ErrorCode::TimingImmutable);
         }
 
         duel_state.duel_key = duel_key;
@@ -721,9 +722,9 @@ pub enum ErrorCode {
     BettingWindowActive,
     #[msg("Duel must be in Challenged status for reproposal")]
     NotChallenged,
-    #[msg("Participant hashes are immutable after betting opens")]
+    #[msg("Participant hashes are immutable after duel prepare")]
     ParticipantHashImmutable,
-    #[msg("Bet timing is immutable after betting opens")]
+    #[msg("Bet timing is immutable after duel prepare")]
     TimingImmutable,
     #[msg("Config is already initialized")]
     AlreadyInitialized,

--- a/packages/hyperbet-solana/anchor/programs/gold_clob_market/src/lib.rs
+++ b/packages/hyperbet-solana/anchor/programs/gold_clob_market/src/lib.rs
@@ -7,7 +7,7 @@ use fight_oracle::{
     self, DuelState as OracleDuelState, DuelStatus as OracleDuelStatus, MarketSide,
 };
 
-declare_id!("3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy");
+declare_id!("EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt");
 
 const CONFIG_SEED: &[u8] = b"config";
 const MARKET_SEED: &[u8] = b"market";
@@ -180,7 +180,8 @@ pub mod gold_clob_market {
             ErrorCode::DuelMismatch
         );
         require!(
-            ctx.accounts.duel_state.status == OracleDuelStatus::BettingOpen
+            ctx.accounts.duel_state.status == OracleDuelStatus::Scheduled
+                || ctx.accounts.duel_state.status == OracleDuelStatus::BettingOpen
                 || ctx.accounts.duel_state.status == OracleDuelStatus::Locked,
             ErrorCode::MarketCreationClosed
         );

--- a/packages/hyperbet-solana/anchor/target/idl/fight_oracle.json
+++ b/packages/hyperbet-solana/anchor/target/idl/fight_oracle.json
@@ -1,5 +1,5 @@
 {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fight_oracle",
     "version": "0.1.0",
@@ -343,7 +343,7 @@
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "program_data"
@@ -1051,12 +1051,12 @@
     {
       "code": 6021,
       "name": "ParticipantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "TimingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-solana/anchor/target/idl/gold_clob_market.json
+++ b/packages/hyperbet-solana/anchor/target/idl/gold_clob_market.json
@@ -1,5 +1,5 @@
 {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "gold_clob_market",
     "version": "0.1.0",
@@ -433,7 +433,7 @@
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "program_data"

--- a/packages/hyperbet-solana/anchor/target/types/fight_oracle.ts
+++ b/packages/hyperbet-solana/anchor/target/types/fight_oracle.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/fight_oracle.json`.
  */
 export type FightOracle = {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fightOracle",
     "version": "0.1.0",
@@ -349,7 +349,7 @@ export type FightOracle = {
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "programData"
@@ -1057,12 +1057,12 @@ export type FightOracle = {
     {
       "code": 6021,
       "name": "participantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "timingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-solana/anchor/target/types/gold_clob_market.ts
+++ b/packages/hyperbet-solana/anchor/target/types/gold_clob_market.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/gold_clob_market.json`.
  */
 export type GoldClobMarket = {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "goldClobMarket",
     "version": "0.1.0",
@@ -439,7 +439,7 @@ export type GoldClobMarket = {
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "programData"

--- a/packages/hyperbet-solana/anchor/tests/gold_clob_market.anchor.ts
+++ b/packages/hyperbet-solana/anchor/tests/gold_clob_market.anchor.ts
@@ -17,6 +17,7 @@ import {
   createOpenMarketFixture,
   duelStatusBettingOpen,
   duelStatusLocked,
+  duelStatusScheduled,
   ensureClobConfig,
   ensureOracleReady,
   finalizeDuelResult,
@@ -119,6 +120,33 @@ describe("gold_clob_market (native SOL settlement)", () => {
         `expected duplicate PDA initialization failure, got ${message}`,
       );
     }
+  });
+
+  it("allows scheduled prestage and keeps the initialized market locked", async () => {
+    await ensureOracleReady(fightProgram, authority, authority.publicKey);
+    const config = await ensureClobConfig(clobProgram, authority);
+
+    const duelKey = uniqueDuelKey("scheduled-market");
+    const now = Math.floor(Date.now() / 1000);
+    const duelState = await upsertDuel(fightProgram, authority, duelKey, {
+      status: duelStatusScheduled(),
+      betOpenTs: now + 30,
+      betCloseTs: now + 600,
+      duelStartTs: now + 660,
+      metadataUri: "https://hyperscape.gg/tests/clob/scheduled",
+    });
+    const market = await initializeCanonicalMarket(
+      clobProgram,
+      authority,
+      duelState,
+      duelKey,
+      config,
+    );
+
+    const marketState = await clobProgram.account.marketState.fetch(
+      market.marketState,
+    );
+    assert.deepStrictEqual(marketState.status, { locked: {} });
   });
 
   it("charges trade fees only on executed taker size and enforces FIFO at a shared price level", async () => {

--- a/packages/hyperbet-solana/anchor/tests/oracle-finality.anchor.ts
+++ b/packages/hyperbet-solana/anchor/tests/oracle-finality.anchor.ts
@@ -12,10 +12,12 @@ import {
   createOpenMarketFixture,
   challengeDuelResult,
   duelStatusLocked,
+  duelStatusScheduled,
   deriveDuelStatePda,
   deriveOracleConfigPda,
   ensureOracleReady,
   finalizeDuelResult,
+  hashLabel,
   hasProgramError,
   marketSideA,
   placeClobOrder,
@@ -36,6 +38,59 @@ describe("oracle finality truth (solana)", () => {
   const fightProgram = anchor.workspace.FightOracle as Program<FightOracle>;
   const clobProgram = anchor.workspace.GoldClobMarket as Program<GoldClobMarket>;
   const authority = (provider.wallet as anchor.Wallet & { payer: Keypair }).payer;
+
+  it("freezes the scheduled duel manifest after prepare", async () => {
+    const duelKey = uniqueDuelKey("sol-scheduled-immutable");
+    const now = Math.floor(Date.now() / 1000);
+    const participantAHash = hashLabel("sol-agent-a");
+    const participantBHash = hashLabel("sol-agent-b");
+
+    await upsertDuel(fightProgram, authority, duelKey, {
+      status: duelStatusScheduled(),
+      betOpenTs: now + 30,
+      betCloseTs: now + 90,
+      duelStartTs: now + 150,
+      participantAHash,
+      participantBHash,
+      metadataUri: "https://hyperscape.gg/tests/prepare/scheduled",
+    });
+
+    try {
+      await upsertDuel(fightProgram, authority, duelKey, {
+        status: duelStatusScheduled(),
+        betOpenTs: now + 30,
+        betCloseTs: now + 90,
+        duelStartTs: now + 151,
+        participantAHash,
+        participantBHash,
+        metadataUri: "https://hyperscape.gg/tests/prepare/scheduled-shifted",
+      });
+      assert.fail("scheduled duel timing mutated after prepare");
+    } catch (error: unknown) {
+      assert.ok(
+        hasProgramError(error, "TimingImmutable"),
+        `expected TimingImmutable, got ${String(error)}`,
+      );
+    }
+
+    try {
+      await upsertDuel(fightProgram, authority, duelKey, {
+        status: duelStatusScheduled(),
+        betOpenTs: now + 30,
+        betCloseTs: now + 90,
+        duelStartTs: now + 150,
+        participantAHash: hashLabel("sol-agent-a-mutated"),
+        participantBHash,
+        metadataUri: "https://hyperscape.gg/tests/prepare/scheduled-mutated",
+      });
+      assert.fail("scheduled duel participant mutated after prepare");
+    } catch (error: unknown) {
+      assert.ok(
+        hasProgramError(error, "ParticipantHashImmutable"),
+        `expected ParticipantHashImmutable, got ${String(error)}`,
+      );
+    }
+  });
 
   it("rejects settlement before terminal oracle states", async () => {
     const maker = Keypair.generate();

--- a/packages/hyperbet-solana/app/src/idl/fight_oracle.json
+++ b/packages/hyperbet-solana/app/src/idl/fight_oracle.json
@@ -1,5 +1,5 @@
 {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fight_oracle",
     "version": "0.1.0",
@@ -343,7 +343,7 @@
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "program_data"
@@ -1051,12 +1051,12 @@
     {
       "code": 6021,
       "name": "ParticipantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "TimingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-solana/app/src/idl/fight_oracle.ts
+++ b/packages/hyperbet-solana/app/src/idl/fight_oracle.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/fight_oracle.json`.
  */
 export type FightOracle = {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fightOracle",
     "version": "0.1.0",
@@ -349,7 +349,7 @@ export type FightOracle = {
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "programData"
@@ -1057,12 +1057,12 @@ export type FightOracle = {
     {
       "code": 6021,
       "name": "participantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "timingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-solana/app/src/idl/gold_clob_market.json
+++ b/packages/hyperbet-solana/app/src/idl/gold_clob_market.json
@@ -1,5 +1,5 @@
 {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "gold_clob_market",
     "version": "0.1.0",
@@ -433,7 +433,7 @@
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "program_data"

--- a/packages/hyperbet-solana/app/src/idl/gold_clob_market.ts
+++ b/packages/hyperbet-solana/app/src/idl/gold_clob_market.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/gold_clob_market.json`.
  */
 export type GoldClobMarket = {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "goldClobMarket",
     "version": "0.1.0",
@@ -439,7 +439,7 @@ export type GoldClobMarket = {
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "programData"

--- a/packages/hyperbet-solana/keeper/src/idl/fight_oracle.json
+++ b/packages/hyperbet-solana/keeper/src/idl/fight_oracle.json
@@ -1,5 +1,5 @@
 {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fight_oracle",
     "version": "0.1.0",
@@ -343,7 +343,7 @@
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "program_data"
@@ -1051,12 +1051,12 @@
     {
       "code": 6021,
       "name": "ParticipantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "TimingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-solana/keeper/src/idl/fight_oracle.ts
+++ b/packages/hyperbet-solana/keeper/src/idl/fight_oracle.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/fight_oracle.json`.
  */
 export type FightOracle = {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fightOracle",
     "version": "0.1.0",
@@ -349,7 +349,7 @@ export type FightOracle = {
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "programData"
@@ -1057,12 +1057,12 @@ export type FightOracle = {
     {
       "code": 6021,
       "name": "participantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "timingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-solana/keeper/src/idl/gold_clob_market.json
+++ b/packages/hyperbet-solana/keeper/src/idl/gold_clob_market.json
@@ -1,5 +1,5 @@
 {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "gold_clob_market",
     "version": "0.1.0",
@@ -433,7 +433,7 @@
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "program_data"

--- a/packages/hyperbet-solana/keeper/src/idl/gold_clob_market.ts
+++ b/packages/hyperbet-solana/keeper/src/idl/gold_clob_market.ts
@@ -5,7 +5,7 @@
  * IDL can be found at `target/idl/gold_clob_market.json`.
  */
 export type GoldClobMarket = {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "goldClobMarket",
     "version": "0.1.0",
@@ -439,7 +439,7 @@ export type GoldClobMarket = {
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "programData"

--- a/packages/hyperbet-ui/src/idl/fight_oracle.json
+++ b/packages/hyperbet-ui/src/idl/fight_oracle.json
@@ -1,5 +1,5 @@
 {
-  "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM",
+  "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB",
   "metadata": {
     "name": "fight_oracle",
     "version": "0.1.0",
@@ -343,7 +343,7 @@
         },
         {
           "name": "program",
-          "address": "GFdnu7kUnZGiXh4ejWiJSBCUxvq4UfdEeUv9jjFzr5EM"
+          "address": "7EXSmAP4fcabojJBQbxN7GcBE4hinqfZao1tJcGLTrfB"
         },
         {
           "name": "program_data"
@@ -1051,12 +1051,12 @@
     {
       "code": 6021,
       "name": "ParticipantHashImmutable",
-      "msg": "Participant hashes are immutable after betting opens"
+      "msg": "Participant hashes are immutable after duel prepare"
     },
     {
       "code": 6022,
       "name": "TimingImmutable",
-      "msg": "Bet timing is immutable after betting opens"
+      "msg": "Bet timing is immutable after duel prepare"
     },
     {
       "code": 6023,

--- a/packages/hyperbet-ui/src/idl/gold_clob_market.json
+++ b/packages/hyperbet-ui/src/idl/gold_clob_market.json
@@ -1,5 +1,5 @@
 {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "gold_clob_market",
     "version": "0.1.0",
@@ -433,7 +433,7 @@
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "program_data"

--- a/packages/market-maker-bot/src/idl/gold_clob_market.json
+++ b/packages/market-maker-bot/src/idl/gold_clob_market.json
@@ -1,5 +1,5 @@
 {
-  "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy",
+  "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt",
   "metadata": {
     "name": "gold_clob_market",
     "version": "0.1.0",
@@ -433,7 +433,7 @@
         },
         {
           "name": "program",
-          "address": "3QUVoaKJqo1rg9eXe7vyFewJrY75NWdtH8JZfvTb79Uy"
+          "address": "EHBdndoQUXZXDtoTcb5D5AimJ1x715vKWzbqLH8entTt"
         },
         {
           "name": "program_data"

--- a/scripts/testnet-acceptance-env.ts
+++ b/scripts/testnet-acceptance-env.ts
@@ -3,7 +3,7 @@ import {
   resolveBettingEvmRuntimeEnv,
   resolveBettingSolanaDeployment,
   type BettingSolanaCluster,
-} from "../packages/hyperbet-chain-registry/src/index.ts";
+} from "../packages/hyperbet-chain-registry/src/index.js";
 
 export type AcceptanceDeployment = "staging" | "testnet";
 export type AcceptanceDuelSource =


### PR DESCRIPTION
## Summary
This draft isolates the contract/program lifecycle semantics, registry truth, and generated artifact sync from the broader Hyperbet umbrella branch.

## Includes
- EVM contract lifecycle/immutability changes
- Solana program lifecycle changes and generated anchor artifacts
- chain-registry and shared IDL sync needed for those semantics

## Excludes
- viewer-aligned UI/state selection work
- AVAX-specific follow-up changes

## Validation
- split from `enoomian/unified-bets-parity-keepers`
- remains draft pending focused contract/program validation in the appropriate harnesses