### PR TITLE
fix(solana): require upgrade authority for lvr amm bootstrap

### DIFF
--- a/packages/hyperbet-avax/keeper/src/idl/lvr_amm.json
+++ b/packages/hyperbet-avax/keeper/src/idl/lvr_amm.json
@@ -674,6 +674,13 @@
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -720,6 +727,13 @@
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
         },
         {
           "name": "system_program",
@@ -1791,6 +1805,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "UnauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-avax/keeper/src/idl/lvr_amm.ts
+++ b/packages/hyperbet-avax/keeper/src/idl/lvr_amm.ts
@@ -680,6 +680,13 @@ export type LvrAmm = {
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
+        },
+        {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
@@ -726,6 +733,13 @@ export type LvrAmm = {
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
         },
         {
           "name": "systemProgram",
@@ -1797,6 +1811,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "unauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-bsc/app/src/idl/lvr_amm.json
+++ b/packages/hyperbet-bsc/app/src/idl/lvr_amm.json
@@ -674,6 +674,13 @@
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -720,6 +727,13 @@
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
         },
         {
           "name": "system_program",
@@ -1791,6 +1805,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "UnauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-bsc/app/src/idl/lvr_amm.ts
+++ b/packages/hyperbet-bsc/app/src/idl/lvr_amm.ts
@@ -680,6 +680,13 @@ export type LvrAmm = {
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
+        },
+        {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
@@ -726,6 +733,13 @@ export type LvrAmm = {
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
         },
         {
           "name": "systemProgram",
@@ -1797,6 +1811,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "unauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-bsc/keeper/src/idl/lvr_amm.json
+++ b/packages/hyperbet-bsc/keeper/src/idl/lvr_amm.json
@@ -674,6 +674,13 @@
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -720,6 +727,13 @@
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
         },
         {
           "name": "system_program",
@@ -1791,6 +1805,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "UnauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-bsc/keeper/src/idl/lvr_amm.ts
+++ b/packages/hyperbet-bsc/keeper/src/idl/lvr_amm.ts
@@ -680,6 +680,13 @@ export type LvrAmm = {
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
+        },
+        {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
@@ -726,6 +733,13 @@ export type LvrAmm = {
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
         },
         {
           "name": "systemProgram",
@@ -1797,6 +1811,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "unauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-evm/keeper/src/idl/lvr_amm.json
+++ b/packages/hyperbet-evm/keeper/src/idl/lvr_amm.json
@@ -674,6 +674,13 @@
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -720,6 +727,13 @@
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
         },
         {
           "name": "system_program",
@@ -1791,6 +1805,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "UnauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-evm/keeper/src/idl/lvr_amm.ts
+++ b/packages/hyperbet-evm/keeper/src/idl/lvr_amm.ts
@@ -680,6 +680,13 @@ export type LvrAmm = {
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
+        },
+        {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
@@ -726,6 +733,13 @@ export type LvrAmm = {
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
         },
         {
           "name": "systemProgram",
@@ -1797,6 +1811,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "unauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-solana/anchor/programs/lvr_amm/src/error.rs
+++ b/packages/hyperbet-solana/anchor/programs/lvr_amm/src/error.rs
@@ -88,4 +88,7 @@ pub enum PredictionMarketError {
 
     #[msg("AMM fixed-point overflow")]
     MathFixedPointOverflow,
+
+    #[msg("Initializer must be the program upgrade authority")]
+    UnauthorizedInitializer,
 }

--- a/packages/hyperbet-solana/anchor/programs/lvr_amm/src/instructions/init.rs
+++ b/packages/hyperbet-solana/anchor/programs/lvr_amm/src/instructions/init.rs
@@ -34,6 +34,14 @@ pub struct InitializeAdmin<'info> {
 
     #[account(mut)]
     pub signer: Signer<'info>,
+    #[account(
+        constraint = program.programdata_address()? == Some(program_data.key()) @ PredictionMarketError::UnauthorizedInitializer
+    )]
+    pub program: Program<'info, crate::program::LvrAmm>,
+    #[account(
+        constraint = program_data.upgrade_authority_address == Some(signer.key()) @ PredictionMarketError::UnauthorizedInitializer
+    )]
+    pub program_data: Account<'info, ProgramData>,
     pub system_program: Program<'info, System>,
 }
 

--- a/packages/hyperbet-solana/anchor/programs/lvr_amm/src/instructions/init_config.rs
+++ b/packages/hyperbet-solana/anchor/programs/lvr_amm/src/instructions/init_config.rs
@@ -77,6 +77,14 @@ pub struct InitializeAmmConfig<'info> {
 
     #[account(mut)]
     pub signer: Signer<'info>,
+    #[account(
+        constraint = program.programdata_address()? == Some(program_data.key()) @ PredictionMarketError::UnauthorizedInitializer
+    )]
+    pub program: Program<'info, crate::program::LvrAmm>,
+    #[account(
+        constraint = program_data.upgrade_authority_address == Some(signer.key()) @ PredictionMarketError::UnauthorizedInitializer
+    )]
+    pub program_data: Account<'info, ProgramData>,
     pub system_program: Program<'info, System>,
 }
 

--- a/packages/hyperbet-solana/anchor/target/idl/lvr_amm.json
+++ b/packages/hyperbet-solana/anchor/target/idl/lvr_amm.json
@@ -674,6 +674,13 @@
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -720,6 +727,13 @@
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
         },
         {
           "name": "system_program",
@@ -1791,6 +1805,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "UnauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-solana/anchor/target/types/lvr_amm.ts
+++ b/packages/hyperbet-solana/anchor/target/types/lvr_amm.ts
@@ -680,6 +680,13 @@ export type LvrAmm = {
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
+        },
+        {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
@@ -726,6 +733,13 @@ export type LvrAmm = {
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
         },
         {
           "name": "systemProgram",
@@ -1797,6 +1811,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "unauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-solana/anchor/tests/amm-test-helpers.ts
+++ b/packages/hyperbet-solana/anchor/tests/amm-test-helpers.ts
@@ -227,6 +227,8 @@ export async function ensureLvrAdmin(
       .accountsPartial({
         adminState,
         signer: authority.publicKey,
+        program: program.programId,
+        programData: deriveProgramDataAddress(program.programId),
         systemProgram: SystemProgram.programId,
       })
       .signers([authority])
@@ -257,6 +259,8 @@ export async function ensureAmmConfig(
       .accountsPartial({
         ammConfig,
         signer: authority.publicKey,
+        program: program.programId,
+        programData: deriveProgramDataAddress(program.programId),
         systemProgram: SystemProgram.programId,
       })
       .signers([authority])

--- a/packages/hyperbet-solana/anchor/tests/lvr_amm_security.anchor.ts
+++ b/packages/hyperbet-solana/anchor/tests/lvr_amm_security.anchor.ts
@@ -26,6 +26,7 @@ import {
   deriveDuelStatePda,
   deriveMintNoPda,
   deriveMintYesPda,
+  deriveProgramDataAddress,
   duelStatusBettingOpen,
   ensureAmmConfig,
   ensureLvrAdmin,
@@ -182,6 +183,43 @@ async function createBetFixture(options?: {
 }
 
 describe("lvr_amm security", () => {
+  it("rejects config initialization by a non-upgrade authority", async function () {
+    const ammConfig = deriveAmmConfigPda(ammProgram.programId);
+    const existingConfig =
+      await (ammProgram.account as any).ammConfig.fetchNullable(ammConfig);
+    if (existingConfig) {
+      this.skip();
+    }
+
+    const attacker = Keypair.generate();
+    await airdrop(provider.connection, attacker.publicKey, 1);
+
+    try {
+      await ammProgram.methods
+        .initializeConfig(
+          attacker.publicKey,
+          attacker.publicKey,
+          fightProgram.programId,
+          200,
+        )
+        .accountsPartial({
+          ammConfig,
+          signer: attacker.publicKey,
+          program: ammProgram.programId,
+          programData: deriveProgramDataAddress(ammProgram.programId),
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([attacker])
+        .rpc();
+      assert.fail("initialize_config accepted a non-upgrade authority");
+    } catch (error: unknown) {
+      assert.ok(
+        hasProgramError(error, "UnauthorizedInitializer"),
+        `expected UnauthorizedInitializer, got ${String(error)}`,
+      );
+    }
+  });
+
   it("rejects settlement with a duel PDA derived from a different duel key", async () => {
     const fixture = await createBetFixture({ expirationOffsetSecs: -60 });
     const now = Math.floor(Date.now() / 1000);

--- a/packages/hyperbet-solana/app/src/idl/lvr_amm.json
+++ b/packages/hyperbet-solana/app/src/idl/lvr_amm.json
@@ -674,6 +674,13 @@
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -720,6 +727,13 @@
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
         },
         {
           "name": "system_program",
@@ -1791,6 +1805,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "UnauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-solana/app/src/idl/lvr_amm.ts
+++ b/packages/hyperbet-solana/app/src/idl/lvr_amm.ts
@@ -680,6 +680,13 @@ export type LvrAmm = {
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
+        },
+        {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
@@ -726,6 +733,13 @@ export type LvrAmm = {
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
         },
         {
           "name": "systemProgram",
@@ -1797,6 +1811,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "unauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-solana/keeper/src/idl/lvr_amm.json
+++ b/packages/hyperbet-solana/keeper/src/idl/lvr_amm.json
@@ -674,6 +674,13 @@
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -720,6 +727,13 @@
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
         },
         {
           "name": "system_program",
@@ -1791,6 +1805,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "UnauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-solana/keeper/src/idl/lvr_amm.ts
+++ b/packages/hyperbet-solana/keeper/src/idl/lvr_amm.ts
@@ -680,6 +680,13 @@ export type LvrAmm = {
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
+        },
+        {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
@@ -726,6 +733,13 @@ export type LvrAmm = {
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "programData"
         },
         {
           "name": "systemProgram",
@@ -1797,6 +1811,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "unauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/hyperbet-ui/src/idl/lvr_amm.json
+++ b/packages/hyperbet-ui/src/idl/lvr_amm.json
@@ -674,6 +674,13 @@
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -720,6 +727,13 @@
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
         },
         {
           "name": "system_program",
@@ -1791,6 +1805,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "UnauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [

--- a/packages/market-maker-bot/src/idl/lvr_amm.json
+++ b/packages/market-maker-bot/src/idl/lvr_amm.json
@@ -674,6 +674,13 @@
           "signer": true
         },
         {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -720,6 +727,13 @@
           "name": "signer",
           "writable": true,
           "signer": true
+        },
+        {
+          "name": "program",
+          "address": "12E8Lz5w8Qxyj8Fh6LgsCgPDQNJMCLMV1y43LhPrH66w"
+        },
+        {
+          "name": "program_data"
         },
         {
           "name": "system_program",
@@ -1791,6 +1805,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "UnauthorizedInitializer",
+      "msg": "Initializer must be the program upgrade authority"
     }
   ],
   "types": [


### PR DESCRIPTION
## Summary

Fixes the Solana `lvr_amm` bootstrap authority gap by making the program upgrade authority the only signer that can initialize the admin/config PDAs.

This is scoped to `enoomian/staging` and is intentionally separated from the dynamic-liquidity mitigation so review can evaluate the bootstrap authority change independently.

## Why

`lvr_amm` previously allowed first-caller-wins initialization for the admin/config accounts. That creates a staging/prod bootstrap takeover risk: any funded signer could initialize the canonical PDAs before the intended deployer and permanently set hostile treasury/authority values.

The expected authority model is the same operational standard used by the other Solana programs: initialization must be tied to the deployed program's upgrade authority, not whichever wallet reaches the endpoint first.

## Changes

- Adds `UnauthorizedInitializer` to the end of `PredictionMarketError` to avoid shifting existing Anchor error codes.
- Requires `program` and `program_data` accounts for `initialize` and `initialize_config`.
- Verifies the passed `ProgramData` account belongs to the active `lvr_amm` program.
- Verifies the signer matches `program_data.upgrade_authority_address`.
- Updates Solana test helpers and generated IDL/type mirrors for anchor/app/keeper consumers.
- Adds a regression test proving a non-upgrade-authority signer cannot initialize config.

## Validation

- `anchor build`
- `ANCHOR_MANUAL_TEST_SKIP_BUILD=1 bun run test tests/lvr_amm_security.anchor.ts tests/lvr_amm_authoritative_settlement.ts`

Targeted localnet result:

- `lvr_amm security`: 8 passing
- `lvr_amm authoritative settlement`: 5 passing

## Rollout Notes

Already-initialized deployments are not affected at runtime. Fresh deployments and migrations must pass the `program` and `programData` accounts when calling `initialize` / `initialize_config`.

This PR should merge into `enoomian/staging` first for staging validation before promotion into any broader release path.
