### PR TITLE
fix(amm): disable unsafe dynamic liquidity markets

### DIFF
--- a/packages/evm-contracts/contracts/lvr_amm/Router.sol
+++ b/packages/evm-contracts/contracts/lvr_amm/Router.sol
@@ -52,6 +52,7 @@ contract Router is ReentrancyGuard, IMarketBuyCallback, IMarketSellCallback, IMa
     error MarketNotAllowed();
     error SlippageExceeded();
     error ConfigFrozen();
+    error DynamicMarketsDisabled();
 
     event FeeConfigUpdated(address indexed treasury, uint256 feeBps);
     event FeeConfigFrozen(address indexed admin);
@@ -114,6 +115,7 @@ contract Router is ReentrancyGuard, IMarketBuyCallback, IMarketSellCallback, IMa
         uint256 collateralIn
     ) public {
         _checkRole(MARKET_OPERATOR_ROLE);
+        if (isDynamic) revert DynamicMarketsDisabled();
         bytes32 marketId = keccak256(abi.encode(title, msg.sender, block.timestamp));
         if (knownMarketIds[marketId]) revert MarketAlreadyExists();
 

--- a/packages/evm-contracts/test/LvrMarket.t.sol
+++ b/packages/evm-contracts/test/LvrMarket.t.sol
@@ -57,7 +57,7 @@ contract LvrMarketTest is Test {
             "Market for BTC price event",
             "coingecko",
             TEST_DUEL_KEY,
-            true,
+            false,
             DURATION,
             collateralIn
         );
@@ -71,11 +71,26 @@ contract LvrMarketTest is Test {
         vm.stopPrank();
     }
 
+    function test_DynamicMarketsDisabled() public {
+        vm.startPrank(admin);
+        vm.expectRevert(Router.DynamicMarketsDisabled.selector);
+        router.create(
+            "Dynamic Market",
+            "Disabled until dynamic liquidity is safe",
+            "coingecko",
+            TEST_DUEL_KEY,
+            true,
+            DURATION,
+            100 * 10**18
+        );
+        vm.stopPrank();
+    }
+
     function test_BuyYes() public {
         uint256 collateralIn = 100 * 10**18;
 
         vm.prank(admin);
-        router.create("Test Market", "Desc", "Src", TEST_DUEL_KEY, true, DURATION, collateralIn);
+        router.create("Test Market", "Desc", "Src", TEST_DUEL_KEY, false, DURATION, collateralIn);
 
         address marketAddr = _marketAt(0);
         LvrMarket market = LvrMarket(marketAddr);
@@ -99,7 +114,7 @@ contract LvrMarketTest is Test {
         uint256 collateralIn = 100 * 10**18;
 
         vm.prank(admin);
-        router.create("Test Market", "Desc", "Src", TEST_DUEL_KEY, true, DURATION, collateralIn);
+        router.create("Test Market", "Desc", "Src", TEST_DUEL_KEY, false, DURATION, collateralIn);
 
         address marketAddr = _marketAt(0);
         LvrMarket market = LvrMarket(marketAddr);
@@ -170,7 +185,7 @@ contract LvrMarketTest is Test {
     function test_CreateRequiresMarketOperatorRole() public {
         vm.startPrank(user1);
         vm.expectRevert();
-        router.create("Test Market", "Desc", "Src", TEST_DUEL_KEY, true, DURATION, 100 * 10**18);
+        router.create("Test Market", "Desc", "Src", TEST_DUEL_KEY, false, DURATION, 100 * 10**18);
         vm.stopPrank();
     }
 
@@ -178,7 +193,7 @@ contract LvrMarketTest is Test {
         uint256 collateralIn = 100 * 10**18;
 
         vm.prank(admin);
-        router.create("Test Market", "Desc", "Src", TEST_DUEL_KEY, true, DURATION, collateralIn);
+        router.create("Test Market", "Desc", "Src", TEST_DUEL_KEY, false, DURATION, collateralIn);
         address marketAddr = _marketAt(0);
 
         vm.warp(block.timestamp + 1 hours);
@@ -195,7 +210,7 @@ contract LvrMarketTest is Test {
         uint256 collateralIn = 100 * 10**18;
 
         vm.prank(admin);
-        router.create("Test Market", "Desc", "Src", TEST_DUEL_KEY, true, DURATION, collateralIn);
+        router.create("Test Market", "Desc", "Src", TEST_DUEL_KEY, false, DURATION, collateralIn);
         address marketAddr = _marketAt(0);
         LvrMarket market = LvrMarket(marketAddr);
 
@@ -212,7 +227,7 @@ contract LvrMarketTest is Test {
 
     function test_SettleMarketRequiresPendingState() public {
         vm.prank(admin);
-        router.create("Test Market", "Desc", "Src", TEST_DUEL_KEY, true, DURATION, 100 * 10**18);
+        router.create("Test Market", "Desc", "Src", TEST_DUEL_KEY, false, DURATION, 100 * 10**18);
         address marketAddr = _marketAt(0);
 
         vm.expectRevert(bytes("Invalid Market State"));
@@ -249,13 +264,13 @@ contract LvrMarketTest is Test {
     function test_ZeroDurationReverts() public {
         vm.startPrank(admin);
         vm.expectRevert(bytes("Duration must be positive"));
-        router.create("Zero Duration", "Desc", "Src", keccak256("zero-dur"), true, 0, 100 * 10**18);
+        router.create("Zero Duration", "Desc", "Src", keccak256("zero-dur"), false, 0, 100 * 10**18);
         vm.stopPrank();
     }
 
     function test_GetPriceAfterDeadline() public {
         vm.prank(admin);
-        router.create("Expiring Market", "Desc", "Src", TEST_DUEL_KEY, true, DURATION, 100 * 10**18);
+        router.create("Expiring Market", "Desc", "Src", TEST_DUEL_KEY, false, DURATION, 100 * 10**18);
         address marketAddr = _marketAt(0);
         LvrMarket market = LvrMarket(marketAddr);
 
@@ -298,7 +313,7 @@ contract LvrMarketTest is Test {
 
     function test_AdminResolveSelectorRemoved() public {
         vm.prank(admin);
-        router.create("Bond Slash Test", "Desc", "Src", TEST_DUEL_KEY, true, DURATION, 100 * 10**18);
+        router.create("Bond Slash Test", "Desc", "Src", TEST_DUEL_KEY, false, DURATION, 100 * 10**18);
         address marketAddr = _marketAt(0);
         (bool success, ) = marketAddr.call(abi.encodeWithSignature("adminResolve(uint256)", 1));
         assertFalse(success, "adminResolve should not remain callable");
@@ -309,7 +324,7 @@ contract LvrMarketTest is Test {
         _setupOracleDuel(duelKey);
 
         vm.prank(admin);
-        router.create("Bond Return Test", "Desc", "Src", duelKey, true, DURATION, 100 * 10**18);
+        router.create("Bond Return Test", "Desc", "Src", duelKey, false, DURATION, 100 * 10**18);
         address marketAddr = _lastMarketAddress();
         LvrMarket market = LvrMarket(marketAddr);
 

--- a/packages/hyperbet-avax/keeper/src/idl/lvr_amm.json
+++ b/packages/hyperbet-avax/keeper/src/idl/lvr_amm.json
@@ -1791,6 +1791,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "DynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-avax/keeper/src/idl/lvr_amm.ts
+++ b/packages/hyperbet-avax/keeper/src/idl/lvr_amm.ts
@@ -1797,6 +1797,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "dynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-bsc/app/src/idl/lvr_amm.json
+++ b/packages/hyperbet-bsc/app/src/idl/lvr_amm.json
@@ -1791,6 +1791,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "DynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-bsc/app/src/idl/lvr_amm.ts
+++ b/packages/hyperbet-bsc/app/src/idl/lvr_amm.ts
@@ -1797,6 +1797,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "dynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-bsc/keeper/src/idl/lvr_amm.json
+++ b/packages/hyperbet-bsc/keeper/src/idl/lvr_amm.json
@@ -1791,6 +1791,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "DynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-bsc/keeper/src/idl/lvr_amm.ts
+++ b/packages/hyperbet-bsc/keeper/src/idl/lvr_amm.ts
@@ -1797,6 +1797,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "dynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-evm/keeper/src/idl/lvr_amm.json
+++ b/packages/hyperbet-evm/keeper/src/idl/lvr_amm.json
@@ -1791,6 +1791,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "DynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-evm/keeper/src/idl/lvr_amm.ts
+++ b/packages/hyperbet-evm/keeper/src/idl/lvr_amm.ts
@@ -1797,6 +1797,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "dynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-solana/anchor/programs/lvr_amm/src/error.rs
+++ b/packages/hyperbet-solana/anchor/programs/lvr_amm/src/error.rs
@@ -88,4 +88,7 @@ pub enum PredictionMarketError {
 
     #[msg("AMM fixed-point overflow")]
     MathFixedPointOverflow,
+
+    #[msg("Dynamic AMM markets are disabled")]
+    DynamicMarketsDisabled,
 }

--- a/packages/hyperbet-solana/anchor/programs/lvr_amm/src/instructions/create_bet.rs
+++ b/packages/hyperbet-solana/anchor/programs/lvr_amm/src/instructions/create_bet.rs
@@ -17,6 +17,7 @@ pub fn create_bet(
 ) -> Result<()> {
     let config = &ctx.accounts.amm_config;
     require!(!config.paused, PredictionMarketError::MarketPaused);
+    require!(!is_dynamic, PredictionMarketError::DynamicMarketsDisabled);
 
     require!(
         initial_liq > 0,

--- a/packages/hyperbet-solana/anchor/target/idl/lvr_amm.json
+++ b/packages/hyperbet-solana/anchor/target/idl/lvr_amm.json
@@ -1791,6 +1791,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "DynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-solana/anchor/target/types/lvr_amm.ts
+++ b/packages/hyperbet-solana/anchor/target/types/lvr_amm.ts
@@ -1797,6 +1797,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "dynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-solana/anchor/tests/amm-test-helpers.ts
+++ b/packages/hyperbet-solana/anchor/tests/amm-test-helpers.ts
@@ -401,7 +401,7 @@ export async function initializeCanonicalMarket(
   const ammConfig = deriveAmmConfigPda(program.programId);
 
   const initialLiq = new BN(LAMPORTS_PER_SOL * 5); // 5 SOL initial liquidity
-  const isDynamic = true;
+  const isDynamic = false;
   const description = "Test AMM Open Market";
   const expirationAt = new BN(Date.now() / 1000 + 3600);
 

--- a/packages/hyperbet-solana/anchor/tests/lvr_amm_security.anchor.ts
+++ b/packages/hyperbet-solana/anchor/tests/lvr_amm_security.anchor.ts
@@ -182,6 +182,21 @@ async function createBetFixture(options?: {
 }
 
 describe("lvr_amm security", () => {
+  it("rejects dynamic market creation while dynamic liquidity is disabled", async () => {
+    try {
+      await createBetFixture({
+        isDynamic: true,
+        expirationOffsetSecs: 300,
+      });
+      assert.fail("create_bet_account accepted a dynamic market");
+    } catch (error: unknown) {
+      assert.ok(
+        hasProgramError(error, "DynamicMarketsDisabled"),
+        `expected DynamicMarketsDisabled, got ${String(error)}`,
+      );
+    }
+  });
+
   it("rejects settlement with a duel PDA derived from a different duel key", async () => {
     const fixture = await createBetFixture({ expirationOffsetSecs: -60 });
     const now = Math.floor(Date.now() / 1000);

--- a/packages/hyperbet-solana/app/src/idl/lvr_amm.json
+++ b/packages/hyperbet-solana/app/src/idl/lvr_amm.json
@@ -1791,6 +1791,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "DynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-solana/app/src/idl/lvr_amm.ts
+++ b/packages/hyperbet-solana/app/src/idl/lvr_amm.ts
@@ -1797,6 +1797,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "dynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-solana/keeper/src/idl/lvr_amm.json
+++ b/packages/hyperbet-solana/keeper/src/idl/lvr_amm.json
@@ -1791,6 +1791,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "DynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-solana/keeper/src/idl/lvr_amm.ts
+++ b/packages/hyperbet-solana/keeper/src/idl/lvr_amm.ts
@@ -1797,6 +1797,11 @@ export type LvrAmm = {
       "code": 6028,
       "name": "mathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "dynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/hyperbet-ui/src/idl/lvr_amm.json
+++ b/packages/hyperbet-ui/src/idl/lvr_amm.json
@@ -1791,6 +1791,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "DynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [

--- a/packages/market-maker-bot/src/idl/lvr_amm.json
+++ b/packages/market-maker-bot/src/idl/lvr_amm.json
@@ -1791,6 +1791,11 @@
       "code": 6028,
       "name": "MathFixedPointOverflow",
       "msg": "AMM fixed-point overflow"
+    },
+    {
+      "code": 6029,
+      "name": "DynamicMarketsDisabled",
+      "msg": "Dynamic AMM markets are disabled"
     }
   ],
   "types": [


### PR DESCRIPTION
## Summary

Disables dynamic LVR AMM market creation across EVM and Solana until the dynamic liquidity math can be redesigned and differentially verified.

This is a short-term safety gate, not the final dynamic-market implementation. It is scoped to `enoomian/staging` so the staging product can continue on static AMM markets without carrying the unsafe dynamic path.

## Why

Audit triage showed the current dynamic AMM path can quote/drain nearly the whole reserve on a small trade under the dynamic pricing model. That is not safe to expose while the dynamic model is unresolved.

The safest forward fix is to fail closed at market creation on every supported runtime:

- EVM `Router.create(..., isDynamic=true, ...)` reverts.
- Solana `create_bet(..., is_dynamic=true, ...)` returns `DynamicMarketsDisabled`.

Static markets remain available and continue to cover the current staging flow.

## Changes

- Adds `DynamicMarketsDisabled` to the EVM router and rejects dynamic market creation.
- Updates EVM LVR tests to exercise static markets by default and adds explicit dynamic rejection coverage.
- Adds `DynamicMarketsDisabled` to the end of the Solana `PredictionMarketError` enum to avoid shifting existing Anchor error codes.
- Rejects Solana dynamic market creation in `create_bet`.
- Updates Solana helpers to create static markets by default.
- Synchronizes generated Solana IDL/type mirrors for anchor/app/keeper consumers.

## Validation

- `FOUNDRY_LIBS='["../../node_modules","lib"]' forge test --match-path test/LvrMarket.t.sol`
- `anchor build`
- `ANCHOR_MANUAL_TEST_SKIP_BUILD=1 bun run test tests/lvr_amm_security.anchor.ts tests/lvr_amm_authoritative_settlement.ts`

Targeted results:

- EVM `LvrMarket.t.sol`: 33 passing
- Solana `lvr_amm security`: 8 passing
- Solana `lvr_amm authoritative settlement`: 5 passing

## Rollout Notes

This intentionally disables dynamic market creation only. It does not delete the dynamic pricing code or claim the dynamic model is fixed. Re-enabling dynamic liquidity should require a follow-up PR with a corrected model plus EVM/Rust/TS differential tests.

This PR should merge into `enoomian/staging` first for staging validation before promotion into any broader release path.
