### PR TITLE
chore(ui): drop unused canonicalPlayback destructure from solana + bsc App

### DIFF
--- a/packages/hyperbet-bsc/app/src/App.tsx
+++ b/packages/hyperbet-bsc/app/src/App.tsx
@@ -733,7 +733,6 @@ export function App() {
   const {
     session: canonicalStreamSession,
     rawSession: rawCanonicalStreamSession,
-    playback: canonicalPlayback,
     rendererHealth: canonicalRendererHealth,
     deliveryHealth: canonicalDeliveryHealth,
     publicReadiness: canonicalPublicReadiness,

--- a/packages/hyperbet-solana/app/src/App.tsx
+++ b/packages/hyperbet-solana/app/src/App.tsx
@@ -762,7 +762,6 @@ export function App() {
   const {
     session: canonicalStreamSession,
     rawSession: rawCanonicalStreamSession,
-    playback: canonicalPlayback,
     rendererHealth: canonicalRendererHealth,
     deliveryHealth: canonicalDeliveryHealth,
     publicReadiness: canonicalPublicReadiness,


### PR DESCRIPTION
## Summary

Removes the unused `playback: canonicalPlayback` destructure from `useCanonicalStreamSession()` in two App shells:

- `packages/hyperbet-solana/app/src/App.tsx:765`
- `packages/hyperbet-bsc/app/src/App.tsx:736`

Both bindings are declared but never read. ESLint's `@typescript-eslint/no-unused-vars` rule (configured with `--max-warnings=0`) hard-fails the **Pre-PR Ready Check** gate as a result.

## Why

This lint debt has been on `enoomian/staging` since before audit kickoff. It is currently blocking the in-flight security PRs:

- [#135 — `fix(solana): require upgrade authority for lvr amm bootstrap`](https://github.com/HyperscapeAI/hyperbet/pull/135)
- [#136 — `fix(amm): disable unsafe dynamic liquidity markets`](https://github.com/HyperscapeAI/hyperbet/pull/136)

Both PRs are otherwise green; their `Pre-PR Ready Check` step fails on `hyperbet-solana app lint` (and `hyperbet-bsc app lint` follows next). Neither PR touches `App.tsx`, so the lint failure is inherited from the base branch, not introduced by them.

This change is the minimal fix to unblock both audit PRs without expanding their scope.

## Changes

- Removes the `playback: canonicalPlayback,` line from the `useCanonicalStreamSession()` destructure in `hyperbet-solana/app/src/App.tsx`.
- Removes the same line from `hyperbet-bsc/app/src/App.tsx`.

The hook return shape is unchanged — `useCanonicalStreamSession()` still exposes `.playback` to any future caller. If a future diff needs the playback field, it can be re-added in the same diff that introduces the consumer.

EVM `App.tsx` was already clean (no `canonicalPlayback` destructure); no change there.

## Validation

- `cd packages/hyperbet-solana/app && bun run lint` — PASS
- `cd packages/hyperbet-bsc/app && bun run lint` — PASS

## Rollout

Merging this into `enoomian/staging` first will unblock the **Pre-PR Ready Check** gate for #135 and #136 so they can be reviewed and merged on their own merits.

## Explicit non-goals

- This PR does NOT change any runtime behavior.
- This PR does NOT touch any audit-scope contract or program code.
- This PR does NOT alter the `useCanonicalStreamSession` hook itself.