### PR TITLE
fix(perps): enforce stale oracle gate on liquidation

### DIFF
--- a/packages/evm-contracts/contracts/perps/AgentPerpEngine.sol
+++ b/packages/evm-contracts/contracts/perps/AgentPerpEngine.sol
@@ -132,7 +132,6 @@ contract AgentPerpEngine is AccessControl, ReentrancyGuard {
     uint256 public immutable defaultSkewScale;
     bool public tradingPaused;
     bool public marketCreationPaused;
-    bool private _isLiquidationContext;
 
     event MarketCreated(
         bytes32 indexed agentId,
@@ -540,9 +539,7 @@ contract AgentPerpEngine is AccessControl, ReentrancyGuard {
         Position storage position = positions[agentId][trader];
         if (position.size == 0) revert NoPosition();
 
-        _isLiquidationContext = true;
         _syncOracle(agentId);
-        _isLiquidationContext = false;
         int256 fundingPayment = _settleFunding(position, market, true);
 
         uint256 markPrice = _markPrice(market, config);
@@ -814,7 +811,7 @@ contract AgentPerpEngine is AccessControl, ReentrancyGuard {
 
         (uint256 mu, uint256 sigma, uint256 lastUpdate) = oracle.agentSkills(agentId);
         if (lastUpdate == 0) revert UnknownOracleAgent();
-        if (!_isLiquidationContext && block.timestamp - lastUpdate > config.maxOracleDelay) revert StaleOracle();
+        if (block.timestamp - lastUpdate > config.maxOracleDelay) revert StaleOracle();
 
         _accrueFunding(market, config);
 

--- a/packages/evm-contracts/contracts/perps/AgentPerpEngineNative.sol
+++ b/packages/evm-contracts/contracts/perps/AgentPerpEngineNative.sol
@@ -102,7 +102,6 @@ contract AgentPerpEngineNative is AccessControl, ReentrancyGuard {
     uint256 public immutable fundingVelocity;
     uint256 public immutable maxLeverage;
     bool public tradingPaused;
-    bool private _isLiquidationContext;
 
     event PositionOpened(
         bytes32 indexed agentId,
@@ -249,9 +248,9 @@ contract AgentPerpEngineNative is AccessControl, ReentrancyGuard {
         }
 
         MarketConfig memory config = marketConfigs[agentId];
-        (uint256 mu,, uint256 lastUpdate) = oracle.agentSkills(agentId);
+        (,, uint256 lastUpdate) = oracle.agentSkills(agentId);
         if (lastUpdate == 0) revert UnknownOracleAgent();
-        if (!_isLiquidationContext && block.timestamp - lastUpdate > config.maxOracleDelay) revert StaleOracle();
+        if (block.timestamp - lastUpdate > config.maxOracleDelay) revert StaleOracle();
 
         _updateFunding(agentId);
         price = oracle.getIndexPrice(agentId);
@@ -536,9 +535,7 @@ contract AgentPerpEngineNative is AccessControl, ReentrancyGuard {
 
     function liquidate(bytes32 agentId, address trader) external nonReentrant {
         if (!marketConfigs[agentId].exists) revert MarketNotFound();
-        _isLiquidationContext = true;
         _syncOracle(agentId);
-        _isLiquidationContext = false;
 
         MarketConfig memory config = marketConfigs[agentId];
         MarketState storage market = markets[agentId];

--- a/packages/evm-contracts/test/perps/AgentPerpEngine.t.sol
+++ b/packages/evm-contracts/test/perps/AgentPerpEngine.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "forge-std/Test.sol";
 import "../../contracts/perps/SkillOracle.sol";
 import "../../contracts/perps/AgentPerpEngine.sol";
+import "../../contracts/perps/AgentPerpEngineNative.sol";
 import "../../contracts/MockERC20.sol";
 
 contract AgentPerpEngineTest is Test {
@@ -92,6 +93,71 @@ contract AgentPerpEngineTest is Test {
         vm.warp(block.timestamp + 3 minutes);
         vm.expectRevert(AgentPerpEngine.StaleOracle.selector);
         engine.syncOracle(agentId);
+    }
+
+    function testOracleStalenessBlocksLiquidation() public {
+        bytes32 staleAgent = keccak256("STALE_AGENT");
+        bytes32 peerAgent = keccak256("STALE_PEER");
+
+        vm.prank(admin);
+        oracle.updateAgentSkill(staleAgent, 1500, 0);
+        vm.prank(admin);
+        oracle.updateAgentSkill(peerAgent, 1500, 0);
+
+        vm.prank(operator);
+        engine.createMarket(
+            staleAgent,
+            1_000_000 * 1e18,
+            5 * 1e18,
+            1_000,
+            500,
+            1 minutes,
+            0,
+            0,
+            0
+        );
+
+        vm.prank(alice);
+        engine.modifyPosition(staleAgent, 100 * 1e18, 4 * 1e18);
+
+        vm.prank(admin);
+        oracle.updateAgentSkill(staleAgent, 1000, 0);
+
+        vm.warp(block.timestamp + 1 minutes + 1);
+
+        vm.prank(bob);
+        vm.expectRevert(AgentPerpEngine.StaleOracle.selector);
+        engine.liquidate(staleAgent, alice);
+    }
+
+    function testNativeOracleStalenessBlocksLiquidation() public {
+        bytes32 staleAgent = keccak256("NATIVE_STALE_AGENT");
+        bytes32 peerAgent = keccak256("NATIVE_STALE_PEER");
+
+        SkillOracle nativeOracle = new SkillOracle(100 * 1e18, 2 hours, admin, admin, pauser);
+        vm.prank(admin);
+        nativeOracle.updateAgentSkill(staleAgent, 1500, 0);
+        vm.prank(admin);
+        nativeOracle.updateAgentSkill(peerAgent, 1500, 0);
+
+        AgentPerpEngineNative nativeEngine =
+            new AgentPerpEngineNative(nativeOracle, 1_000_000 * 1e18, admin, operator, pauser);
+
+        vm.prank(operator);
+        nativeEngine.createMarket(staleAgent);
+
+        vm.deal(alice, 1_000 ether);
+        vm.prank(alice);
+        nativeEngine.modifyPosition{value: 100 ether}(staleAgent, 4 * 1e18);
+
+        vm.prank(admin);
+        nativeOracle.updateAgentSkill(staleAgent, 1000, 0);
+
+        vm.warp(block.timestamp + nativeEngine.DEFAULT_MAX_ORACLE_DELAY() + 1);
+
+        vm.prank(bob);
+        vm.expectRevert(AgentPerpEngineNative.StaleOracle.selector);
+        nativeEngine.liquidate(staleAgent, alice);
     }
 
     function testOracleStalenessBlocksGetIndexPrice() public {


### PR DESCRIPTION
## Summary

This PR fixes the stale-oracle liquidation bypass in the EVM perps engines. Liquidation now uses the same max-oracle-delay gate as normal perps oracle sync instead of entering a special liquidation context that allowed stale-but-still-oracle-readable prices.

## Security invariant

A liquidation must not execute from an oracle price older than the market engine maxOracleDelay, even if the underlying SkillOracle has a longer max delay.

## Changes

- remove the liquidation-context stale-oracle bypass from AgentPerpEngine
- remove the same bypass from AgentPerpEngineNative
- add ERC20 and native regression tests proving stale oracle data blocks liquidation

## Validation

- bun install --frozen-lockfile: pass
- git submodule update --init --recursive packages/evm-contracts/lib/solady: pass
- FOUNDRY_LIBS=["../../node_modules","lib"] forge test --match-path test/perps/AgentPerpEngine.t.sol --match-test "test(OracleStalenessBlocksLiquidation|NativeOracleStalenessBlocksLiquidation)": 2 passed
- FOUNDRY_LIBS=["../../node_modules","lib"] forge test --match-path test/perps/AgentPerpEngine.t.sol: 50 passed
- FOUNDRY_LIBS=["../../node_modules","lib"] forge test --match-path test/perps/AgentPerpEngineFuzz.t.sol: 2 passed
- FOUNDRY_LIBS=["../../node_modules","lib"] forge test --match-path test/adversarial/PmPerpsAdversarial.t.sol: 11 passed
- git diff --check: pass

## Notes

Draft until owner/security review is complete. This branch targets main as the effective PR path; the same commit will be replayed into enoomian staging separately for deployment testing.