### PR TITLE
fix(amm): settle lvr markets from duel oracle

### DIFF
--- a/packages/evm-contracts/contracts/lvr_amm/LvrMarket.sol
+++ b/packages/evm-contracts/contracts/lvr_amm/LvrMarket.sol
@@ -127,14 +127,14 @@ contract LvrMarket is ReentrancyGuard {
     function settleMarket() external isRouter nonReentrant {
         require(state == MarketState.PENDING, "Invalid Market State");
         require(block.timestamp >= resolutionTimestamp, "Challenge Window Open");
-        // Return bond to proposer with Reward collected through market fees
-        state = MarketState.RESOLVED;
-        IERC20(collateralToken).safeTransfer(proposer, bondValue); // Add fees and then reward the proposer
-
-        emit MarketSettled(outcome, proposer, bondValue);
+        _settleFromOracle();
     }
 
     function settleFromOracle() external isRouter nonReentrant {
+        _settleFromOracle();
+    }
+
+    function _settleFromOracle() private {
         require(state == MarketState.OPEN || state == MarketState.PENDING || state == MarketState.DISPUTED, "Invalid Market State");
 
         // Capture proposer's outcome before overwriting (for bond slashing)

--- a/packages/evm-contracts/test/LvrMarket.t.sol
+++ b/packages/evm-contracts/test/LvrMarket.t.sol
@@ -219,6 +219,61 @@ contract LvrMarketTest is Test {
         router.settleMarket(marketAddr);
     }
 
+    function test_ManualSettlementCannotResolveWithoutOracleResult() public {
+        bytes32 duelKey = keccak256("manual-settle-no-oracle-result");
+
+        vm.prank(admin);
+        router.create("Manual Oracle Gate", "Desc", "Src", duelKey, false, DURATION, 100 * 10**18);
+        address marketAddr = _lastMarketAddress();
+        LvrMarket market = LvrMarket(marketAddr);
+
+        vm.warp(block.timestamp + DURATION);
+
+        uint256 bond = market.bondValue();
+        vm.prank(user1);
+        mUSD.approve(address(router), bond);
+        vm.prank(user1);
+        router.proposerOutcome(marketAddr, 0);
+
+        vm.warp(block.timestamp + 5 minutes + 1);
+
+        vm.expectRevert(bytes("Oracle duel not resolved"));
+        router.settleMarket(marketAddr);
+
+        (LvrMarket.MarketState currentState,,,,,,,) = market.getMarketDetails();
+        assertEq(uint256(currentState), uint256(LvrMarket.MarketState.PENDING), "market should stay pending");
+    }
+
+    function test_SettleMarketUsesOracleOutcomeAfterManualProposal() public {
+        bytes32 duelKey = keccak256("manual-settle-oracle-authority");
+        _setupOracleDuel(duelKey);
+
+        vm.prank(admin);
+        router.create("Manual Oracle Override", "Desc", "Src", duelKey, false, DURATION, 100 * 10**18);
+        address marketAddr = _lastMarketAddress();
+        LvrMarket market = LvrMarket(marketAddr);
+
+        vm.warp(block.timestamp + DURATION);
+
+        uint256 bond = market.bondValue();
+        vm.prank(user1);
+        mUSD.approve(address(router), bond);
+        vm.prank(user1);
+        router.proposerOutcome(marketAddr, 0);
+
+        _proposeAndFinalizeOracle(duelKey, DuelOutcomeOracle.Side.B);
+
+        uint256 treasuryBefore = mUSD.balanceOf(treasury);
+        uint256 proposerBefore = mUSD.balanceOf(user1);
+        router.settleMarket(marketAddr);
+
+        (LvrMarket.MarketState currentState,, uint256 mktOutcome,,,,,) = market.getMarketDetails();
+        assertEq(uint256(currentState), uint256(LvrMarket.MarketState.RESOLVED));
+        assertEq(mktOutcome, 1, "manual settlement must use the oracle outcome");
+        assertEq(mUSD.balanceOf(treasury), treasuryBefore + bond, "wrong proposer bond should be slashed");
+        assertEq(mUSD.balanceOf(user1), proposerBefore, "wrong proposer should not receive bond");
+    }
+
     function test_RedeemCollateralPaysWinningSide() public {
         bytes32 duelKey = keccak256("redeem-winning-side");
         _setupOracleDuel(duelKey);


### PR DESCRIPTION
## Summary

Fixes the LVR manual-settlement authority gap found during the contract audit.

Before this patch, a manual proposal could move an `LvrMarket` from `PENDING` to `RESOLVED` through `settleMarket()` after the dispute window without consulting `DuelOutcomeOracle`. That made the manual proposer path an alternate settlement authority and could block the oracle-backed outcome from ever being applied.

This patch keeps the existing manual proposal and dispute-window mechanics, but final settlement now always routes through the same oracle-backed settlement path used by `settleFromOracle()`.

## Security Impact

- `settleMarket()` no longer resolves from the proposer-provided outcome directly.
- `settleMarket()` now requires the duel oracle to be resolved before the market can resolve.
- Wrong manual proposals are slashed according to the oracle outcome instead of becoming final truth.
- Existing `settleFromOracle()` behavior is preserved through a shared private settlement helper.

## Verification

- Red-path regression was confirmed before the fix: the new tests failed against the vulnerable behavior.
- `env FOUNDRY_LIBS='["../../node_modules","lib"]' forge test --match-path test/LvrMarket.t.sol --match-test 'test_(ManualSettlementCannotResolveWithoutOracleResult|SettleMarketUsesOracleOutcomeAfterManualProposal)'` -> 2 passed, 0 failed
- `env FOUNDRY_LIBS='["../../node_modules","lib"]' forge test --match-path test/LvrMarket.t.sol` -> 34 passed, 0 failed
- `git diff --check` -> pass

## Staging Policy

This PR targets `main` and is intentionally draft while review is pending. The same patch is replayed into `enoomian/staging` for staging deployment and testing, but this effective PR remains open as the merge vehicle.
