### PR TITLE
fix(perps): enforce native equity health on withdrawals

### DIFF
--- a/packages/evm-contracts/contracts/perps/AgentPerpEngineNative.sol
+++ b/packages/evm-contracts/contracts/perps/AgentPerpEngineNative.sol
@@ -391,13 +391,18 @@ contract AgentPerpEngineNative is AccessControl, ReentrancyGuard {
         revert CloseOnlyMode();
     }
 
-    function _assertLeverage(bytes32 agentId, int256 size, uint256 margin) internal view {
+    function _assertPositionHealthy(bytes32 agentId, int256 size, uint256 margin, uint256 entryPrice) internal view {
         if (size == 0) return;
         if (margin == 0) revert Undercollateralized();
         MarketConfig memory config = marketConfigs[agentId];
         uint256 absSize = _abs(size);
-        uint256 execPrice = _getExecutionPrice(agentId, 0);
-        if (Math.mulDiv(absSize, execPrice, margin) > config.maxLeverage) revert MaxLeverageExceeded();
+        uint256 markPrice = _getExecutionPrice(agentId, 0);
+        int256 unrealizedPnl = _realizePnl(size, entryPrice, markPrice, absSize);
+        int256 equity = int256(margin) + unrealizedPnl;
+        if (equity <= 0) revert Underwater();
+
+        uint256 notional = Math.mulDiv(absSize, markPrice, ONE);
+        if (Math.mulDiv(notional, ONE, uint256(equity)) > config.maxLeverage) revert MaxLeverageExceeded();
     }
 
     // ── Position management ──
@@ -502,7 +507,7 @@ contract AgentPerpEngineNative is AccessControl, ReentrancyGuard {
             }
         }
 
-        _assertLeverage(agentId, pos.size, pos.margin);
+        _assertPositionHealthy(agentId, pos.size, pos.margin, pos.entryPrice);
 
         // Track open positions counter
         if (oldSize == 0 && pos.size != 0) {
@@ -524,10 +529,30 @@ contract AgentPerpEngineNative is AccessControl, ReentrancyGuard {
 
     function withdrawMargin(bytes32 agentId, uint256 amount) external nonReentrant {
         if (tradingPaused) revert TradingPaused();
+        if (!marketConfigs[agentId].exists) revert MarketNotFound();
+        _syncOracle(agentId);
+
+        MarketState storage market = markets[agentId];
         Position storage pos = positions[agentId][msg.sender];
+
+        if (pos.size != 0) {
+            int256 rateDelta = market.cumulativeFundingRate - pos.lastCumulativeFundingRate;
+            if (rateDelta != 0) {
+                int256 fundingPayment = (pos.size * rateDelta) / int256(ONE);
+                if (fundingPayment > 0) {
+                    uint256 loss = uint256(fundingPayment);
+                    if (pos.margin < loss) revert Underwater();
+                    pos.margin -= loss;
+                } else {
+                    pos.margin += uint256(-fundingPayment);
+                }
+            }
+            pos.lastCumulativeFundingRate = market.cumulativeFundingRate;
+        }
+
         if (pos.margin < amount) revert InsufficientMargin();
-        _assertLeverage(agentId, pos.size, pos.margin - amount);
         pos.margin -= amount;
+        _assertPositionHealthy(agentId, pos.size, pos.margin, pos.entryPrice);
         emit MarginWithdrawn(agentId, msg.sender, amount);
         Address.sendValue(payable(msg.sender), amount);
     }

--- a/packages/evm-contracts/test/perps/AgentPerpEngine.t.sol
+++ b/packages/evm-contracts/test/perps/AgentPerpEngine.t.sol
@@ -790,4 +790,16 @@ contract AgentPerpEngineNativeHealthTest is Test {
         vm.prank(alice);
         engine.withdrawMargin(agentId, 1 ether);
     }
+
+    function testNativeModifyPositionRejectsNegativeEquityAfterOracleMove() public {
+        vm.prank(alice);
+        engine.modifyPosition{value: 200 ether}(agentId, int256(5 ether));
+
+        vm.prank(admin);
+        oracle.updateAgentSkill(agentId, 1500, 100);
+
+        vm.expectRevert(AgentPerpEngineNative.Underwater.selector);
+        vm.prank(alice);
+        engine.modifyPosition{value: 1 ether}(agentId, int256(1 ether));
+    }
 }

--- a/packages/evm-contracts/test/perps/AgentPerpEngine.t.sol
+++ b/packages/evm-contracts/test/perps/AgentPerpEngine.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "forge-std/Test.sol";
 import "../../contracts/perps/SkillOracle.sol";
 import "../../contracts/perps/AgentPerpEngine.sol";
+import "../../contracts/perps/AgentPerpEngineNative.sol";
 import "../../contracts/MockERC20.sol";
 
 contract AgentPerpEngineTest is Test {
@@ -748,5 +749,45 @@ contract AgentPerpEngineTest is Test {
         // Both fees at 5% (max allowed)
         vm.prank(operator);
         engine.createMarket(agentB, 1_000_000 * 1e18, 5 * 1e18, 1_000, 500, 2 minutes, 0, 500, 500);
+    }
+}
+
+contract AgentPerpEngineNativeHealthTest is Test {
+    SkillOracle oracle;
+    AgentPerpEngineNative engine;
+
+    address admin = address(1);
+    address operator = address(6);
+    address pauser = address(7);
+    address alice = address(2);
+
+    bytes32 agentId = keccak256("MODEL_A");
+
+    function setUp() public {
+        vm.txGasPrice(0);
+        vm.warp(1_000);
+
+        vm.startPrank(admin);
+        oracle = new SkillOracle(100 * 1e18, 2 minutes, admin, admin, pauser);
+        engine = new AgentPerpEngineNative(oracle, 1_000_000 * 1e18, admin, operator, pauser);
+        oracle.updateAgentSkill(agentId, 1500, 0);
+        vm.stopPrank();
+
+        vm.prank(operator);
+        engine.createMarket(agentId);
+
+        vm.deal(alice, 1_000 ether);
+    }
+
+    function testNativeWithdrawMarginRejectsNegativeEquityAfterOracleMove() public {
+        vm.prank(alice);
+        engine.modifyPosition{value: 200 ether}(agentId, int256(5 ether));
+
+        vm.prank(admin);
+        oracle.updateAgentSkill(agentId, 1500, 100);
+
+        vm.expectRevert(AgentPerpEngineNative.Underwater.selector);
+        vm.prank(alice);
+        engine.withdrawMargin(agentId, 1 ether);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the native perps health-check issue found during the contract audit.

Before this patch, `AgentPerpEngineNative` checked leverage using raw margin only. After an adverse oracle move, a position could have negative equity while still passing the raw `notional / margin` check, and `withdrawMargin()` did not sync the oracle before evaluating the withdrawal.

This patch brings the native health gate in line with the ERC20 engine: health is evaluated against equity, where `equity = margin + unrealizedPnl`.

## Security Impact

- Native perps health checks now reject `equity <= 0`.
- Max leverage is computed as `notional / equity`, not `notional / raw margin`.
- `withdrawMargin()` now requires a live market, syncs the oracle, settles funding, subtracts the withdrawal, then checks equity before sending ETH.
- `modifyPosition()` uses the same equity-aware health gate after position changes.

## Verification

- Red-path regression was confirmed before the fix: `testNativeWithdrawMarginRejectsNegativeEquityAfterOracleMove` failed because the withdrawal did not revert.
- `env FOUNDRY_LIBS='["../../node_modules","lib"]' forge test --match-path test/perps/AgentPerpEngine.t.sol --match-test testNativeWithdrawMarginRejectsNegativeEquityAfterOracleMove` -> 1 passed, 0 failed
- `env FOUNDRY_LIBS='["../../node_modules","lib"]' forge test --match-path test/perps/AgentPerpEngine.t.sol` -> 49 passed, 0 failed
- `env FOUNDRY_LIBS='["../../node_modules","lib"]' forge test --match-path test/perps/AgentPerpEngineFuzz.t.sol` -> 2 passed, 0 failed
- `env FOUNDRY_LIBS='["../../node_modules","lib"]' forge test --match-path test/adversarial/PmPerpsAdversarial.t.sol` -> 11 passed, 0 failed
- `git diff --check` -> pass

## Staging Policy

This PR targets `main` and is intentionally draft while review is pending. The same patch will be replayed into `enoomian/staging` for staging deployment and testing, but this effective PR remains open as the merge vehicle.

## Follow-up

This PR fixes the withdrawal/health-gate portion. The separate native liquidation accounting finding remains open because it requires PnL realization, insurance draw, and bad-debt accounting changes in the liquidation path.
