### PR TITLE
fix(ci): install app-local playwright browsers

### DIFF
--- a/.github/workflows/prediction-market-gates.yml
+++ b/.github/workflows/prediction-market-gates.yml
@@ -258,7 +258,8 @@ jobs:
         run: bun run dev:bootstrap
 
       - name: Install Playwright browser
-        run: bunx playwright install --with-deps chromium
+        working-directory: packages/hyperbet-${{ matrix.chain }}/app
+        run: ./node_modules/.bin/playwright install --with-deps chromium
 
       - name: AVAX gate posture note
         if: matrix.chain == 'avax'

--- a/packages/hyperbet-solana/app/scripts/run-e2e-local.sh
+++ b/packages/hyperbet-solana/app/scripts/run-e2e-local.sh
@@ -518,7 +518,10 @@ sleep 2
 write_control_file
 
 echo "[e2e] running playwright tests"
-E2E_BASE_URL="http://127.0.0.1:$APP_PORT" \
-E2E_GAME_API_URL="$GAME_API_URL" \
-E2E_ARENA_WRITE_KEY="$E2E_ARENA_WRITE_KEY" \
-  bunx playwright test --config "$APP_DIR/tests/e2e/playwright.config.ts" "$@"
+(
+  cd "$APP_DIR"
+  E2E_BASE_URL="http://127.0.0.1:$APP_PORT" \
+  E2E_GAME_API_URL="$GAME_API_URL" \
+  E2E_ARENA_WRITE_KEY="$E2E_ARENA_WRITE_KEY" \
+    ./node_modules/.bin/playwright test --config "$APP_DIR/tests/e2e/playwright.config.ts" "$@"
+)


### PR DESCRIPTION
## Summary
- installs Playwright Chromium from the matrix app package instead of root `bunx` so the downloaded browser revision matches the app-local `@playwright/test` version
- runs Solana local E2E through the app-local Playwright binary, matching BSC and AVAX behavior

## Evidence
PR #145 cross-chain E2E installed `chromium_headless_shell-1217` at root, then app-local Playwright looked for `chromium_headless_shell-1208`, causing all three Cross-Chain E2E jobs to fail before product assertions ran.

## Validation
- `git diff --check`
- `bash -n packages/hyperbet-solana/app/scripts/run-e2e-local.sh`